### PR TITLE
feat(skills): add first Agent Skill — write-spec with adapter contract, validation CLI, and specify refactor

### DIFF
--- a/.documentation/devspark-and-codex.md
+++ b/.documentation/devspark-and-codex.md
@@ -1,0 +1,192 @@
+# DevSpark and Codex
+
+Codex is strongest when it has clear task context, durable repository guidance, and a verification loop. DevSpark supplies that operating system: command prompts, specs, plans, tasks, gates, scripts, and release artifacts that keep Codex focused from idea through merge.
+
+Use this guide when you want Codex to do more than answer a one-off coding question. It explains how to combine Codex best practices with the DevSpark lifecycle.
+
+## What Each Tool Owns
+
+| Layer | Codex owns | DevSpark owns |
+|-------|------------|---------------|
+| Reasoning and edits | Reads code, proposes changes, runs commands, applies patches | Gives Codex the workflow and acceptance criteria |
+| Durable guidance | Loads `AGENTS.md` and scoped instructions | Writes and references constitution, specs, plans, tasks, and gates |
+| Reusable workflow | Uses prompts, skills, plugins, and `codex exec` | Provides `/devspark.*` command shims and stock prompt resolution |
+| Verification | Runs tests, lint, builds, and reviews | Defines when to run validation and where to record outcomes |
+| Team memory | Uses project files as context | Preserves decisions and release history under `.documentation/` |
+
+The practical rule is simple: let Codex execute work, and let DevSpark shape the work into a reviewable lifecycle.
+
+## Configure Codex for DevSpark
+
+Start with the [Codex quickstart prompt](../quickstart/devspark_quickstart_codex.md). It installs:
+
+- `.devspark/defaults/commands/` - stock DevSpark command prompts
+- `.codex/prompts/` - Codex prompt shims for `/devspark.*`
+- `.documentation/` - project-owned artifacts, specs, decisions, and overrides
+- `AGENTS.md` - repository guidance Codex can load automatically
+
+Keep `AGENTS.md` short and durable. It should tell Codex where DevSpark files live, how prompt resolution works, and which files are user-owned. Avoid putting long process manuals in `AGENTS.md`; link to DevSpark docs instead.
+
+Recommended `AGENTS.md` guidance:
+
+```markdown
+# AGENTS.md
+
+## DevSpark
+
+- Framework files live in `.devspark/`.
+- Project artifacts and team overrides live in `.documentation/`.
+- Resolve DevSpark commands through the first existing file:
+  1. `.documentation/{git-user}/commands/devspark.{name}.md`
+  2. `.documentation/commands/devspark.{name}.md`
+  3. `.devspark/defaults/commands/devspark.{name}.md`
+- Preserve `.documentation/`; upgrades refresh `.devspark/` only.
+```
+
+Codex discovers `AGENTS.md` from global and project scopes, then merges files from the repository root down to the current directory. More specific files override broader guidance, so nested `AGENTS.md` files are useful for monorepos with different service rules.
+
+## Prompt Codex Through DevSpark
+
+Codex prompts work best when they include goal, context, constraints, and done criteria. DevSpark commands force that shape by turning vague requests into explicit artifacts.
+
+Use this pattern:
+
+```text
+/devspark.specify Add account lockout after five failed login attempts.
+Done when the API returns a clear lockout response, audit events are recorded,
+and existing successful-login behavior is unchanged.
+```
+
+Then continue:
+
+```text
+/devspark.plan Use the existing auth service and current test framework.
+/devspark.tasks
+/devspark.implement
+```
+
+For ambiguous work, ask Codex to plan before coding:
+
+```text
+/plan Read the current spec and plan files. Identify unknowns before implementation.
+```
+
+For narrow fixes, let `/devspark.specify` route the work. It can recommend a one-off fix, quick spec, or full spec and ask for confirmation before artifacts are created.
+
+## Use The Right Reasoning Level
+
+Codex supports different reasoning levels. Match the setting to the DevSpark stage:
+
+| DevSpark stage | Codex setting | Why |
+|----------------|---------------|-----|
+| Small typo, copy, or isolated test fix | Low | Fast turnaround and low risk |
+| Normal feature implementation | Medium or High | Enough reasoning for code and tests |
+| Architecture, migration, or hard debugging | High or Extra High | Better for long-horizon work |
+| Review and risk analysis | High | Finds cross-file regressions and missing tests |
+
+Use lower effort for well-scoped tasks after `/devspark.tasks`. Use higher effort for `/devspark.plan`, `/devspark.critic`, `/devspark.pr-review`, and complex `/devspark.implement` runs.
+
+## Keep Context Lean
+
+DevSpark creates many artifacts. Give Codex the smallest set that can answer the current question.
+
+Good context sets:
+
+- For planning: `spec.md`, constitution, relevant app docs, and current architecture files
+- For implementation: `tasks.md`, `plan.md`, target source files, and related tests
+- For review: PR diff, constitution, spec status, completed tasks, and test output
+- For release: completed specs, merged PRs, changelog, and prior release notes
+
+Avoid pasting entire directories into one prompt. Ask Codex to read the relevant files itself, then summarize what it loaded before making changes.
+
+## Run A Tight Validation Loop
+
+The best DevSpark and Codex workflow is evidence-driven:
+
+1. `/devspark.specify` defines the outcome.
+2. `/devspark.plan` decides the approach.
+3. `/devspark.tasks` creates executable work.
+4. `/devspark.implement` changes code and runs focused tests.
+5. `/devspark.pr-review` checks the result against the constitution and spec.
+6. `/devspark.address-pr-review` fixes review findings in isolation.
+7. `/devspark.release` archives completed work and updates release notes.
+
+Tell Codex exactly what verification is required before it stops:
+
+```text
+Run the focused tests for the files you changed. If they fail, fix the issue.
+If a full suite is too expensive, explain what was run and what remains.
+```
+
+For frontend work, add visual verification. For API work, add contract or integration checks. For shared libraries, add both unit tests and at least one caller-facing check.
+
+## Automate Stable Workflows
+
+For repeatable terminal automation, use the DevSpark harness or Codex non-interactive mode.
+
+DevSpark harness:
+
+```bash
+devspark harness run sample.harness.yaml --adapter codex
+```
+
+Codex non-interactive mode:
+
+```bash
+cat prompt.txt | codex exec --sandbox workspace-write -
+```
+
+Use non-interactive automation for narrow, stable workflows. Keep prompts explicit: state the goal, files to inspect, allowed changes, validation command, and stopping condition.
+
+Avoid broad prompts such as "improve the project" in automation. Prefer:
+
+```text
+Read the failing test output, identify the smallest code change needed,
+implement only that change, run the same test command again, and stop.
+```
+
+## Use Skills When A Workflow Repeats
+
+Codex skills package task-specific instructions, scripts, references, and assets. DevSpark already uses a command-to-skill model for portable capability instructions.
+
+Create or install a skill when:
+
+- A team repeats the same investigation or implementation workflow
+- The workflow has stable reference material
+- Scripts can gather context more reliably than a pasted prompt
+- The instructions should be reused across repositories
+
+Keep slash commands for DevSpark lifecycle orchestration. Use skills for specialist execution patterns, such as writing a spec, auditing an API surface, or gathering domain-specific context.
+
+## Team Practices
+
+Use these conventions for reliable Codex outcomes:
+
+- Commit `AGENTS.md` with concise DevSpark rules.
+- Commit `.codex/prompts/devspark.*.md` if your team uses Codex prompt discovery.
+- Keep team overrides in `.documentation/commands/`.
+- Keep personal overrides in `.documentation/{git-user}/commands/`.
+- Do not commit Codex auth files, tokens, or machine-local configuration.
+- Use `/devspark.personalize` for repeated prompt adjustments instead of editing stock prompts.
+- Run `/devspark.harvest` after large efforts to preserve useful findings and reduce stale context.
+
+## Common Failure Modes
+
+| Failure mode | Fix |
+|--------------|-----|
+| Codex starts coding before scope is clear | Use `/plan` or `/devspark.specify` first |
+| Codex edits too many unrelated files | Add constraints and done criteria before `/devspark.implement` |
+| Context gets too large | Point Codex to specific artifacts and ask it to summarize loaded context |
+| Review feedback is mixed into feature commits | Use `/devspark.address-pr-review` for isolated fixes |
+| Upgrade overwrites team work | Keep team work under `.documentation/`; DevSpark upgrades only refresh `.devspark/` |
+| `/devspark.*` does not appear in Codex CLI | Restart Codex, or set session-scoped `CODEX_HOME` to `.codex` |
+
+## Reference Links
+
+- [Codex Quickstart](https://developers.openai.com/codex/quickstart)
+- [Codex best practices](https://developers.openai.com/codex/learn/best-practices)
+- [Custom instructions with AGENTS.md](https://developers.openai.com/codex/guides/agents-md)
+- [Codex non-interactive mode](https://developers.openai.com/codex/noninteractive)
+- [Codex skills](https://developers.openai.com/codex/skills)
+- [DevSpark Quick Start](quickstart.md)
+- [Harness Engineering](harness-engineering.md)

--- a/.documentation/index.md
+++ b/.documentation/index.md
@@ -86,6 +86,7 @@ Follow the [Quick Start Guide](quickstart.md) to bootstrap DevSpark with a singl
 
 - [Implementation Lifecycle Guide](implementation-lifecycle.md) — Prompt-first quickstart, feature workflow, and updates
 - [Quick Start Guide](quickstart.md) — Prompt bootstrap + 5-step workflow
+- [DevSpark and Codex](devspark-and-codex.md) — Best practices for pairing Codex with DevSpark
 - [Other Ways to Get Started](installation.md) — Advanced manual and CLI options
 - [Upgrade Guide](upgrade.md) — Prompt-first updates, CLI optional
 - [Harness Engineering](harness-engineering.md) — Declarative runtime, adapters, artifacts, and operator guidance

--- a/.documentation/index.md
+++ b/.documentation/index.md
@@ -38,7 +38,6 @@ For teams that want terminal-driven execution, DevSpark also ships an additive C
 **Live Site**: [https://dev.makeboldspark.com](https://dev.makeboldspark.com)
 
 > **DevSpark** is a structured development process for AI coding assistants — 28 slash-command prompts plus helper templates and scripts that give any AI agent a repeatable workflow from requirements through release.
-
 > Built by [Mark Hazleton](https://markhazleton.com) — Mark Hazleton, Solutions Architect
 > DevSpark is part of the [Make Bold Spark](https://makeboldspark.com) portfolio of technical demonstrations.
 

--- a/.documentation/quickstart.md
+++ b/.documentation/quickstart.md
@@ -24,6 +24,14 @@ Follow the instructions at https://raw.githubusercontent.com/markhazleton/devspa
 Follow the instructions at https://raw.githubusercontent.com/markhazleton/devspark/main/quickstart/devspark_quickstart_cursor.md
 ```
 
+### Codex
+
+```text
+Follow the instructions at https://raw.githubusercontent.com/markhazleton/devspark/main/quickstart/devspark_quickstart_codex.md
+```
+
+For Codex-specific workflow guidance, see [DevSpark and Codex](devspark-and-codex.md).
+
 ### Any Other Agent
 
 ```text
@@ -116,6 +124,7 @@ See [Implementation Lifecycle](implementation-lifecycle.md) for the full spec st
 ## What's Next
 
 - [Upgrade Guide](upgrade.md) -- keep DevSpark current
+- [DevSpark and Codex](devspark-and-codex.md) -- best practices for using Codex with DevSpark
 - [Implementation Lifecycle](implementation-lifecycle.md) -- full workflow overview
 - [Harness Engineering](harness-engineering.md) -- optional CLI runtime for declarative workflows
 - [Harness Strict Template](../templates/workflows/harness-strict-template.md) -- delivery-integrity defaults for hands-off runs

--- a/.documentation/specs/003-add-first-skill/checklists/requirements.md
+++ b/.documentation/specs/003-add-first-skill/checklists/requirements.md
@@ -1,0 +1,39 @@
+# Specification Quality Checklist: Add First Agent Skill (write-spec)
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-05-19
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] Frontmatter matches the shared validation contract
+- [x] Required headings for the selected route are present in canonical order
+- [x] Status line uses a valid lifecycle state
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [ ] No [NEEDS CLARIFICATION] markers remain — **1 marker present (FR-020 distribution surface); resolve via `/devspark.clarify`**
+- [x] Requirements are testable and unambiguous (except the one explicitly flagged)
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria (or carry a `[NEEDS CLARIFICATION]` marker)
+- [x] User scenarios cover primary flows (P1: portable skill execution, P1: command-invokes-skill internal pivot, P2: validation)
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Revised 2026-05-19: incorporated tactical guidance (DevSpark-as-orchestrator positioning, command→invokes→skill pivot, context-engineering emphasis, 2A–2D sub-phasing). 3 prior `[NEEDS CLARIFICATION]` markers resolved via Clarifications session 2026-05-19; FR-020 distribution surface remains open.
+- Items marked incomplete require spec updates before `/devspark.plan`.
+- Constitution touchpoints integrated into FRs: §I (FR-016), §III (FR-017), §V (Rationale tradeoffs), §VI (FR-009), §VIII (FR-018).

--- a/.documentation/specs/003-add-first-skill/gates/analyze.md
+++ b/.documentation/specs/003-add-first-skill/gates/analyze.md
@@ -1,0 +1,221 @@
+---
+gate: analyze
+status: pass
+blocking: false
+severity: info
+summary: "27/27 requirements covered; 3 medium findings resolved in tasks.md. All findings closed."
+---
+
+# Specification Analysis Report: 003-add-first-skill
+
+**Analyzed**: 2026-05-19
+**Artifacts**: spec.md, plan.md, tasks.md
+**Spec metadata**: `classification: full-spec`, `risk_level: medium`,
+`required_gates: checklist, analyze, critic`
+
+---
+
+## Findings
+
+| ID | Category | Severity | Location(s) | Summary | Recommendation |
+| --- | --- | --- | --- | --- | --- |
+| F1 | Coverage | MEDIUM | tasks.md T007; spec.md SC-005 | SC-005 requires a new-contributor guide complete enough to allow a second skill on the first PR attempt. T007 creates `templates/skills/README.md` as a landing page with pointers, but the task description does not explicitly require the onboarding walkthrough depth SC-005 demands. | Expand T007 description to require: (a) step-by-step new-skill walkthrough referencing T004 contract + T011 SKILL.md as the example, or (b) confirm `devspark-skills-guide.md` (T006) carries the walkthrough and T007 just links to it — make the split explicit. |
+| F2 | Underspecification | MEDIUM | tasks.md T019; spec.md FR-012(c) | T019 authors `test_adapter_contract.py` and includes a skip/xfail marker for the delegation assertion (to be enabled in T026 after the 2D refactor). FR-012(c) also requires "the existing `/devspark.specify` integration tests still pass against the refactored command." However T019's skip structure means CI could pass pre-2D with the integration tests not yet run under the new adapter path — the enforcement point is T027, but T019 as written does not make this sequential dependency explicit in its own task description. | Amend T019 description to note: "integration-test pass assertion is a stub (expected-pass pointing to T027); do not mark as full coverage until T027 is complete." Or add a dependency note to T019 linking it to T027. |
+| F3 | Inconsistency | MEDIUM | tasks.md Phase 2 header; tasks.md Phase 2 constitution block | Phase 2 header references "T016 ensures 27 other commands are untouched" and "T019, T020 require dual PowerShell + Bash" — but T016 in Phase 2 is a markdownlint run task, and T019/T020 are in Phase 4 (test/CLI tasks). The task ID cross-references in the constitution-enforcement note appear to reference the wrong task numbers. | Update the constitution enforcement note in Phase 2 to use correct IDs: §I → T003/T023/T031; §VI → T013/T014; §VIII → T010 (already correct). |
+
+---
+
+## Coverage Summary Table
+
+| Requirement Key | Has Task? | Task IDs | Notes |
+| --------------- | --------- | -------- | ----- |
+| `adapter-contract-file` (FR-001) | ✓ | T005 | Full coverage |
+| `skill-validation-contract-file` (FR-002) | ✓ | T004 | Full coverage |
+| `devspark-skills-guide-file` (FR-002a) | ✓ | T006 | Full coverage |
+| `adapter-assigns-responsibility` (FR-003) | ✓ | T005 | Content requirement on T005 |
+| `skill-md-open-spec-compliant` (FR-004) | ✓ | T011, T015 | Authoring + manual validation |
+| `skill-metadata-version` (FR-004a) | ✓ | T011, T015, T018 | Authoring + manual + test |
+| `skill-description-discovery-rich` (FR-005) | ✓ | T011 | Authoring task |
+| `skill-body-drafting-workflow` (FR-006) | ✓ | T011 | Authoring task |
+| `skill-body-budget` (FR-007) | ✓ | T011, T012, T018 | Budget enforced in authoring + test |
+| `skill-context-engineering` (FR-008) | ✓ | T013, T014, T017 | Scripts authored + run-verified |
+| `skill-script-platform-parity` (FR-009) | ✓ | T013, T014 | Explicit dual-script tasks |
+| `skill-graceful-degradation` (FR-010) | ✓ | T013, T014, T017 | Degradation in both script tasks |
+| `skill-validation-tests` (FR-011) | ✓ | T018, T022 | Test authored + run |
+| `adapter-contract-test` (FR-012) | ✓ | T019, T026, T028 | Stub + enable + run |
+| `skills-cli-commands` (FR-013) | ✓ | T020, T021, T033, T034 | Author + wire + verify |
+| `specify-thin-wrapper-refactor` (FR-014) | ✓ | T024, T025 | Read-first + refactor |
+| `specify-integration-tests-pass` (FR-015) | ✓ | T027, T028 | Run verify tasks |
+| `other-commands-unchanged` (FR-016) | ✓ | T003, T023, T031 | Regression baseline tasks |
+| `no-documentation-dir-writes` (FR-017) | ✓ | Architectural — no active write task needed; enforced by omission | Constitution §III; no task produces `.documentation/` writes |
+| `markdownlint-zero-errors` (FR-018) | ✓ | T002, T010, T016, T029, T030 | Multi-phase lint gates |
+| `readme-claude-md-updates` (FR-019) | ✓ | T008, T009, T035 | Author + verify |
+| `in-repo-distribution-only` (FR-020) | ✓ | Architectural — no publication task present; enforced by out-of-scope note | |
+| `us1-portable-skill` (US1/SC-001) | ✓ | T011–T017, T032 | Full coverage including manual portability check |
+| `us2-command-invokes-skill` (US2/SC-003) | ✓ | T024–T029 | Full coverage |
+| `us3-validation-cli` (US3/SC-002) | ✓ | T018–T023, T033, T034 | Full coverage |
+| `sc-005-contributor-guide` (SC-005) | ⚠ | T006, T007 | **See F1** — depth of walkthrough is underspecified in task descriptions |
+| `sc-007-context-engineering-trace` (SC-007) | ✓ | T017 | Script execution + JSON verification |
+
+---
+
+## Constitution Alignment Issues
+
+No MUST-level violations found. All §I–§VIII principles are addressed:
+
+- **§I Backward Compatibility**: T003 (regression baseline), T023, T031 (regression confirmation). 27 other commands explicitly out-of-scope.
+- **§II Explicit Over Implied**: Adapter contract (T005) documents all scope boundaries explicitly; multi-app scope noted as command-only in T025.
+- **§III Ownership Boundary**: No task writes to any `.documentation/` path outside the spec artifact directory (which is repository-owned, not framework-installed). FR-017 enforced architecturally.
+- **§IV Governance Authority**: Constitution remains authoritative; skill surface inherits all mandatory rules.
+- **§V Simplicity**: Single skill, minimal adapter, no configuration layer. Tradeoffs documented in spec Rationale Summary.
+- **§VI Platform Parity**: T013 and T014 are explicit parallel tasks for PS and Bash scripts. T017 verifies both.
+- **§VII PR Review Artifact Commit Discipline**: No violation — this is not a PR review artifact commit; standard commit guidance applies.
+- **§VIII Markdown Quality**: Lint gates at T002, T010, T016, T029, T030 ensure zero errors at each phase checkpoint, not just at the end.
+
+---
+
+## Unmapped Tasks
+
+All 35 tasks map to at least one requirement or user story. No orphan tasks found.
+
+| Task | Primary Mapping |
+| ---- | --------------- |
+| T001 | Infrastructure prerequisite (setup gate) |
+| T002 | FR-018, §VIII |
+| T003 | FR-016, SC-006 |
+| T004 | FR-002 |
+| T005 | FR-001, FR-003 |
+| T006 | FR-002a, SC-005 |
+| T007 | FR-019, SC-005 |
+| T008 | FR-019 |
+| T009 | FR-019 |
+| T010 | FR-018, §VIII |
+| T011 | FR-004, FR-004a, FR-005, FR-006, FR-007 |
+| T012 | FR-007 |
+| T013 | FR-008, FR-009, FR-010 |
+| T014 | FR-009, FR-010 |
+| T015 | FR-004, FR-004a, SC-001 |
+| T016 | FR-018, §VIII |
+| T017 | FR-008, SC-007 |
+| T018 | FR-011, SC-002 |
+| T019 | FR-012, SC-003 |
+| T020 | FR-013 |
+| T021 | FR-013 |
+| T022 | SC-002, FR-011, FR-013 |
+| T023 | FR-016, SC-006 |
+| T024 | FR-014 (prerequisite read) |
+| T025 | FR-014, FR-015 |
+| T026 | FR-012 |
+| T027 | FR-015, SC-003 |
+| T028 | FR-012, SC-003 |
+| T029 | FR-018, §VIII |
+| T030 | FR-018, SC-004, §VIII |
+| T031 | SC-006, FR-016 |
+| T032 | SC-001, US1 acceptance scenario 1 |
+| T033 | FR-013, SC-002 |
+| T034 | FR-013, SC-002 |
+| T035 | FR-019 |
+
+---
+
+## Metrics
+
+- **Total Requirements**: 27 (20 FRs + 3 USs + 4 SCs with distinct coverage needs)
+- **Total Tasks**: 35
+- **Coverage %**: 100% (27/27 requirements have ≥1 task)
+- **Ambiguity Count**: 0 (all requirements are worded with MUST/SHOULD and measurable outcomes)
+- **Duplication Count**: 0 (no near-duplicate requirements detected)
+- **Critical Issues Count**: 0
+- **High Issues Count**: 0
+- **Medium Issues Count**: 3 (F1, F2, F3)
+- **Low Issues Count**: 0
+
+---
+
+## Structured Findings (Resolution Contract)
+
+```yaml
+findings:
+  - finding_id: analyze-001
+    severity: medium
+    description: >
+      SC-005 requires a new-contributor guide deep enough to enable a second skill
+      on the first PR attempt. T007 (templates/skills/README.md) is described only
+      as a "landing page with pointers." It is unclear whether T007 or T006
+      (devspark-skills-guide.md) carries the step-by-step walkthrough SC-005 demands.
+      The task descriptions do not make this split explicit.
+    recommended_action: >
+      Expand T007 description to explicitly include the new-skill walkthrough steps,
+      OR confirm that T006 carries the walkthrough and amend T007 to say
+      "landing page; walkthrough lives in T006." Pick one owner and state it.
+    execution_mode: manual
+    status: resolved
+    outcome: "T006 designated as SC-005 walkthrough owner; T006 description expanded
+      to require numbered steps for new-skill workflow; T007 clarified as pointer-only
+      landing page with note that walkthrough lives in T006."
+
+  - finding_id: analyze-002
+    severity: medium
+    description: >
+      T019 authors test_adapter_contract.py with an xfail/skip stub for the
+      delegation assertion (FR-012c), to be enabled in T026. The task description
+      does not explicitly note that the integration-test pass check (FR-012c) is
+      not fully enforced until T027 completes. A reviewer reading only T019 could
+      conclude FR-012(c) is satisfied earlier than it actually is.
+    recommended_action: >
+      Add a note to T019 clarifying: "Integration-test pass assertion (FR-012c) is
+      a stub pointing to T027; T019 alone does not satisfy FR-012(c)." This is a
+      documentation-only fix to tasks.md — no implementation change needed.
+    execution_mode: manual
+    status: resolved
+    outcome: "T019 description updated with explicit note: FR-012(c) integration-test
+      pass assertion is a stub pointing to T027; T019 alone does not satisfy FR-012(c)."
+
+  - finding_id: analyze-003
+    severity: medium
+    description: >
+      The constitution-enforcement note at the top of Phase 2 in tasks.md cites
+      "T016 ensures 27 other commands are untouched" and "T019, T020 require dual
+      PowerShell + Bash." In the final task numbering, T016 is the Phase 3
+      markdownlint run (not a backward-compatibility check), and T019/T020 are
+      Phase 4 test-file tasks (not script-parity tasks). The correct IDs are:
+      §I → T003/T023/T031; §VI → T013/T014; §VIII → T010.
+    recommended_action: >
+      Update the constitution-enforcement note in Phase 2 of tasks.md to reference
+      the correct task IDs. This is a documentation-only fix — no implementation
+      change needed.
+    execution_mode: auto
+    status: resolved
+    outcome: "Phase 2 constitution-enforcement note updated to correct IDs:
+      §I → T003/T023/T031; §VI → T013/T014; §VIII → T010."
+```
+
+---
+
+## Next Actions
+
+No CRITICAL or HIGH issues. All three findings are MEDIUM and are documentation
+corrections to `tasks.md` — they do not affect implementation deliverables.
+
+**Recommended before `/devspark.implement`:**
+
+1. **F3 (analyze-003)** — Fix the incorrect task ID references in the Phase 2
+   constitution-enforcement note in `tasks.md`. This is the most mechanical fix
+   (`auto` execution mode) and takes < 1 minute.
+
+2. **F1 (analyze-001)** — Clarify whether T006 or T007 owns the SC-005
+   contributor walkthrough. Update whichever task description is the designated
+   owner to include the walkthrough requirement explicitly.
+
+3. **F2 (analyze-002)** — Add one sentence to T019 noting the integration-test
+   stub will not be fully enforced until T027. Prevents a future reviewer from
+   misreading coverage.
+
+**You may proceed to `/devspark.implement` now** — none of the findings are
+blocking. If you prefer to address them first, edit `tasks.md` in-place before
+starting implementation.
+
+The required gate per spec frontmatter is also `critic` — running
+`/devspark.critic` is recommended before implementation begins for the
+production-readiness perspective (failure modes, scale considerations,
+archetype-specific traps).

--- a/.documentation/specs/003-add-first-skill/gates/critic.md
+++ b/.documentation/specs/003-add-first-skill/gates/critic.md
@@ -1,0 +1,324 @@
+---
+gate: critic
+status: pass
+blocking: false
+severity: info
+summary: "0 showstoppers, 0 critical. All 8 findings (4 high, 4 medium) resolved in spec/plan/tasks. PROCEED."
+---
+
+## Technical Risk Assessment
+
+**Analysis Date:** 2026-05-19
+**Scope:** FULL (spec.md + plan.md + tasks.md)
+**Detected Archetype:** `cli` (primary) + `library` (secondary — `skills.py` exposes a Python API surface)
+**Detected Stack:** Python 3.11+ · Typer + Rich · PyYAML · pytest · PowerShell + Bash scripts
+**Context Mode:** brownfield (new subcommand group + command refactor in established CLI)
+**Risk Profile:** `internal` (defaulted — no `risk_profile` in spec.md frontmatter)
+**Risk Posture:** YELLOW
+
+Checklists loaded from `templates/risk-checklists/cli.md` and `templates/risk-checklists/library.md`.
+No `.devspark/risk-checklists/` overrides found.
+
+---
+
+### Executive Summary
+
+No showstoppers or critical findings. The feature's architectural separation
+(command/adapter/skill) is sound, and the sub-phase sequencing (2A→2B→2C→2D)
+reduces brownfield regression risk appropriately. The primary risks are: (1) the
+`skills validate` CLI subcommand has underspecified exit-code semantics for the
+`warn` tier (body-budget advisory), (2) PyYAML's YAML 1.1 parser can misread
+frontmatter boolean-like values in ways that silently pass validation, (3) the
+adapter contract's delegation mechanism is prose-only in a Markdown prompt —
+there is no machine-enforced boundary between command and skill at runtime, so
+drift is detectable only by the test suite, and (4) the `specify.md` refactor
+touches a heavily-exercised brownfield command and has no rollback path beyond
+git revert if behavior drift is discovered post-merge.
+
+---
+
+### Findings
+
+```yaml
+findings:
+  - finding_id: critic-001
+    category: missing-risk-profile
+    archetype_applicable: true
+    location: spec.md#frontmatter
+    description: >
+      spec.md frontmatter has no `risk_profile` field. Defaulted to `internal`
+      (no severity shift applied). If this tool ships to end-users or is used in
+      CI pipelines affecting production repositories, the profile should be
+      `customer-facing`, which would shift HIGH findings to CRITICAL.
+    base_severity: high
+    effective_severity: high
+    recommended_action: >
+      Add `risk_profile: internal` (or appropriate value) to spec.md frontmatter
+      to make the default explicit and suppress this finding on re-run.
+    execution_mode: auto
+    status: resolved
+    outcome: "Added risk_profile: internal and change_type: brownfield to spec.md frontmatter."
+
+  - finding_id: critic-002
+    category: cli_ergonomics
+    archetype_applicable: true
+    location: tasks.md#T020; plan.md#contracts/cli-commands.md
+    description: >
+      The `devspark skills validate` exit-code contract specifies exit 0 (pass)
+      and exit 1 (failure), but the SKILL-validation-contract.md introduces a
+      three-tier result: pass / warn / fail. Body-budget pressure produces a
+      `warn`, not a `fail`. The tasks and plan do not define whether `warn`
+      exits 0 or 1. If it exits 0, CI will silently pass oversized skills; if it
+      exits 1, implementers will have to decide during coding with no spec
+      guidance. The CLI checklist requires documented exit codes.
+    base_severity: high
+    effective_severity: high
+    recommended_action: >
+      Add to the adapter contract or SKILL-validation-contract.md: "warn exits 0
+      with a non-zero warning count on stdout/stderr; fail exits 1." Update
+      contracts/cli-commands.md in tasks.md (Phase 1 of 2A deliverables, T004)
+      to include the three-tier exit-code table. This is a contract authoring
+      decision, not a code change.
+    execution_mode: manual
+    status: resolved
+    outcome: "Three-tier exit-code table (pass=0, warn=0+stderr-count, fail=1) added to
+      T004 task description and plan.md contracts/cli-commands.md section."
+
+  - finding_id: critic-003
+    category: testing_strategy
+    archetype_applicable: true
+    location: tasks.md#T018; spec.md#FR-011
+    description: >
+      `test_skill_contract.py` (T018) plans to parse SKILL.md frontmatter with
+      PyYAML. PyYAML uses YAML 1.1 semantics by default: bare `yes`, `no`,
+      `on`, `off`, `true`, `false` in frontmatter are parsed as Python booleans,
+      not strings. A future skill description containing "on" as a standalone
+      word, or a metadata value like `version: 1.0` (unquoted), could be
+      silently mistyped. T018 specifies `metadata.version` must be a "quoted
+      semver string" but the test assertion is likely a string equality check —
+      PyYAML will produce a float for `version: 1.0` (unquoted) and the test
+      would correctly catch that, but a `version: "1.0"` (quoted) parsed as
+      string `"1.0"` may not enforce the full `MAJOR.MINOR.PATCH` semver pattern.
+      No test task explicitly asserts the semver regex.
+    base_severity: high
+    effective_severity: high
+    recommended_action: >
+      In T018, explicitly assert: (a) `metadata.version` is a string (not int
+      or float — rejects unquoted `1.0`); (b) `metadata.version` matches regex
+      `^\d+\.\d+\.\d+$` (rejects `"1.0"` missing patch). Use `ruamel.yaml`
+      (YAML 1.2) or add a PyYAML `Loader=yaml.SafeLoader` with explicit string
+      enforcement to avoid YAML 1.1 boolean surprises on other frontmatter values.
+    execution_mode: manual
+    status: resolved
+    outcome: "T018 updated to use yaml.safe_load(), assert metadata.version is str type,
+      assert regex ^\\d+\\.\\d+\\.\\d+$, and include deliberate-violation fixtures for
+      unquoted float and partial semver. Portability body-scan (critic-008) also added."
+
+  - finding_id: critic-004
+    category: api_compatibility
+    archetype_applicable: true
+    location: plan.md#Adapter-Input-Map; spec.md#FR-014
+    description: >
+      The adapter contract maps `$FEATURE_DESCRIPTION`, `$CONSTITUTION_PATH`,
+      and `$PRIOR_SPEC_SUMMARY` as named inputs from command to skill. In a
+      Markdown prompt system, "passing named inputs" is prose convention, not
+      enforced by a runtime. The adapter contract test (T019/T026) checks that
+      `specify.md` "references the write-spec skill" and "does not duplicate the
+      drafting procedure inline" — both are text-grep assertions. If the skill
+      body is updated to rename or remove an expected input variable, the grep
+      test will still pass. There is no machine-checked interface between the
+      command and the skill at the variable level.
+    base_severity: high
+    effective_severity: high
+    recommended_action: >
+      Add at least one test assertion that the named input variables
+      (`$FEATURE_DESCRIPTION`, `$CONSTITUTION_PATH`, `$PRIOR_SPEC_SUMMARY`)
+      are referenced in `specify.md`'s delegation block AND declared in the
+      ADAPTER-contract.md. This is a grep-based cross-file consistency check
+      that makes the contract machine-verifiable without a runtime. Document in
+      ADAPTER-contract.md that variable names are part of the versioned contract
+      surface — changing them requires a version bump in `metadata.version`.
+    execution_mode: manual
+    status: resolved
+    outcome: "T019 updated to include cross-file grep assertions for $FEATURE_DESCRIPTION,
+      $CONSTITUTION_PATH, $PRIOR_SPEC_SUMMARY in both specify.md and ADAPTER-contract.md."
+
+  - finding_id: critic-005
+    category: error_handling_resilience
+    archetype_applicable: true
+    location: spec.md#FR-010; tasks.md#T013; tasks.md#T014
+    description: >
+      The context-gathering scripts must "degrade gracefully" and "never block
+      skill execution." The tasks specify JSON output with a `skipped_context`
+      array, but do not specify what the skill should do when the script itself
+      fails to produce valid JSON (e.g., script exits non-zero, or stdout is
+      empty, or malformed JSON). If the skill attempts to parse an empty or
+      broken JSON payload without guarding, the skill activation fails rather
+      than degrading. This is a gap between the graceful-degradation requirement
+      and the skill body's error handling.
+    base_severity: medium
+    effective_severity: medium
+    recommended_action: >
+      Add to T011 (SKILL.md authoring) and T013/T014 (script authoring):
+      the skill MUST treat any non-JSON, empty, or error output from the
+      context scripts as equivalent to `{"constitution_summary": null,
+      "prior_specs": [], "skipped_context": ["script-error"]}`. Document this
+      fallback in the skill body's context-loading section and in the script's
+      error-output contract.
+    execution_mode: manual
+    status: resolved
+    outcome: "T011 updated with explicit fallback JSON contract for broken/empty/non-JSON
+      script output. T013 and T014 updated to always exit 0 and always emit valid JSON
+      with skipped_context array for any unavailable context."
+
+  - finding_id: critic-006
+    category: dependency_supply_chain
+    archetype_applicable: true
+    location: plan.md#Technical-Context; tasks.md (no task)
+    description: >
+      PyYAML is used by the new `test_skill_contract.py` and
+      `src/devspark_cli/commands/skills.py` for frontmatter parsing. No task
+      verifies that PyYAML is already in the project's pinned dependency set
+      (`pyproject.toml` / lockfile). If it is only a transitive dependency,
+      adding an explicit import without a declared direct dependency risks
+      breakage on future lockfile regeneration. The library checklist requires
+      direct dependencies to be declared correctly.
+    base_severity: medium
+    effective_severity: medium
+    recommended_action: >
+      Add a setup task (or amend T001) to verify PyYAML is declared as a direct
+      dependency in `pyproject.toml`. If not, add it with a pinned version range
+      consistent with the existing lockfile. Consider `ruamel.yaml` as an
+      alternative (YAML 1.2, avoids critic-003 boolean surprises).
+    execution_mode: selective
+    status: resolved
+    outcome: "PyYAML>=6.0 confirmed as direct dependency in pyproject.toml. T001 updated
+      to include verification step. plan.md Technical Context updated to note confirmed
+      status."
+
+  - finding_id: critic-007
+    category: cli_ergonomics
+    archetype_applicable: true
+    location: tasks.md#T020; tasks.md#T021
+    description: >
+      `devspark skills list` is spec'd to print a table (name, version, path,
+      status). The existing CLI uses Rich for output. No task specifies whether
+      `skills list` supports `--json` output for scripting consumption
+      (e.g., CI workflows that want to enumerate skills programmatically). The
+      CLI checklist requires a structured output mode for scripting. Omitting it
+      now means adding it later as a breaking change (output format change).
+    base_severity: medium
+    effective_severity: medium
+    recommended_action: >
+      Decide and document in T020 whether `skills list` will support `--json`
+      flag in this feature. If deferred, add an explicit note to the adapter
+      contract that the output format is not yet stable so consumers know not
+      to parse it. A one-line `--json` flag costs minimal effort now vs.
+      a semver-breaking change later.
+    execution_mode: manual
+    status: resolved
+    outcome: "T020 updated: no --json flag in this release (explicitly deferred with
+      comment that output format is not yet stable); three-tier exit codes added;
+      SafeLoader specified. plan.md contracts section notes output format instability."
+
+  - finding_id: critic-008
+    category: testing_strategy
+    archetype_applicable: true
+    location: tasks.md#T032; spec.md#SC-001
+    description: >
+      T032 (manual portability check) is the only verification for SC-001 —
+      that the skill works in a non-DevSpark client. This is a manual task in
+      the Polish phase, performed after all implementation is complete. If the
+      skill body inadvertently references a DevSpark-specific path, variable, or
+      assumption that only works inside a DevSpark-enabled repo, the failure is
+      discovered at the last possible moment. There is no automated check that
+      the SKILL.md body contains no DevSpark-specific instructions.
+    base_severity: medium
+    effective_severity: medium
+    recommended_action: >
+      Add a lightweight automated test to `test_skill_contract.py` (T018) that
+      scans the SKILL.md body for known DevSpark-specific strings (`.devspark/`,
+      `{SCRIPT}`, `FEATURE_DIR`, `{AGENT_SCRIPT}`, `handoffs:`) and fails if
+      any are found. This catches the most common portability regressions
+      mechanically without requiring a live non-DevSpark client.
+    execution_mode: selective
+    status: resolved
+    outcome: "T018 updated to include portability body-scan: asserts SKILL.md body contains
+      none of .devspark/, {SCRIPT}, FEATURE_DIR, {AGENT_SCRIPT}, handoffs: — included
+      in deliberate-violation fixture set."
+```
+
+---
+
+### High
+
+| ID | Category | Location | Issue | Impact | Suggestion |
+| --- | --- | --- | --- | --- | --- |
+| critic-001 | missing-risk-profile | spec.md#frontmatter | No `risk_profile` field; defaulted to `internal` | Future severity re-runs may produce wrong thresholds if profile changes | Add `risk_profile: internal` to spec.md frontmatter |
+| critic-002 | cli_ergonomics | tasks.md#T020, contracts/cli-commands.md | `warn` tier exit code undefined for `skills validate` | CI silently passes oversized skills (exit 0) or breaks unexpectedly (exit 1) with no spec guidance | Define exit-code table (pass=0, warn=0+warning-count, fail=1) in T004/SKILL-validation-contract.md |
+| critic-003 | testing_strategy | tasks.md#T018 | PyYAML YAML 1.1 boolean surprises; semver pattern not regex-enforced | `version: 1.0` (unquoted float) or partial semver silently passes validation | Assert `metadata.version` is a string matching `^\d+\.\d+\.\d+$`; consider `ruamel.yaml` |
+| critic-004 | api_compatibility | plan.md#Adapter-Input-Map | Adapter input variable names are prose-only; no machine check | Variable rename in skill body or command passes grep tests; drift undetected | Add cross-file grep assertions for `$FEATURE_DESCRIPTION`, `$CONSTITUTION_PATH`, `$PRIOR_SPEC_SUMMARY` in adapter contract test |
+
+---
+
+### Questionable Assumptions
+
+1. **"Behavior parity for `/devspark.specify` can be enforced by the existing integration test suite without new behavioral tests"** (spec.md Assumptions) → Failure mode: The existing `test_create_spec_workflow_integration.py` tests are workflow-runner contract tests (T-020 in that file checks workflow YAML structure), not end-to-end prompt-behavior tests. If the thin-wrapper refactor changes how the agent receives its instructions (prompt shape, ordering, variable names), the workflow runner tests may still pass while the actual agent behavior drifts. The test gap is real but accepted by the spec; implementers should be aware when authoring T025.
+
+2. **"The open Agent Skills specification remains stable in the fields used by this feature"** (spec.md Assumptions) → Failure mode: If agentskills.io updates the spec to require new mandatory frontmatter fields (e.g., a `schema_version` key) or deprecates `metadata.version` in favor of a top-level `version`, the `write-spec` skill fails validation at clients without any CI signal. Mitigation: pin the spec version reviewed (2026-05-19) in `devspark-skills-guide.md` and add a note to re-review on upstream spec releases.
+
+3. **"PyYAML can parse all skill frontmatter correctly"** → Failure mode: See critic-003. YAML 1.1 parses `on`/`off`/`yes`/`no` as booleans; a skill description containing "Turn on spec-drafting mode" has `on` as a YAML key if improperly quoted. Scoped risk, but worth one defensive test assertion.
+
+4. **"The `write-spec/references/` files are loaded by the agent on demand"** → Failure mode: Progressive disclosure relies on client support. If a client loads the entire skill folder eagerly at startup (not uncommon in early adopters), the references/ files consume context budget regardless of task relevance. The `SKILL.md` body-length budget (500 lines) is respected, but `references/` has no stated size budget. Large reference files could bloat context. Mitigation: add a total-references size advisory (e.g., `references/` should stay under 2000 lines total) to `devspark-skills-guide.md`.
+
+---
+
+### Dependency Risk Assessment
+
+| Dependency | Concern | Alternative |
+| --- | --- | --- |
+| PyYAML (implicit via transitive) | YAML 1.1 boolean surprises; may not be a declared direct dependency | `ruamel.yaml` (YAML 1.2, no boolean surprises); declare as direct dep |
+| agentskills.io specification (external, no pinning) | Spec could change; no CI signal for upstream changes | Pin spec version reviewed in guide; note re-review trigger |
+| `npx markdownlint-cli2` (via npx) | npx fetches latest if not cached; version drift in CI | Pin version in `package.json` devDependencies or CI step |
+| PowerShell 5.1+ (assumed) | Scripts may use PS 7+ features unavailable on macOS/Linux PS 7 default | Test scripts on both PS 5.1 (Windows) and PS 7 (cross-platform) |
+
+---
+
+### Estimated Technical Debt at Launch
+
+- **Testing Debt**: PyYAML semver-regex assertion missing (critic-003); portability body-scan missing (critic-008); adapter variable cross-check missing (critic-004). Estimated 2–3 test assertions to add.
+- **Documentation Debt**: `warn` exit-code tier undocumented (critic-002); `references/` size advisory absent from guide (assumption 4); spec version pinning absent from guide (assumption 2).
+- **Operational Debt**: No `--json` output for `skills list` means scripting consumers must screen-scrape (critic-007). Deferred but noted.
+- **Dependency Debt**: PyYAML not confirmed as declared direct dependency (critic-006); `npx` version not pinned.
+
+---
+
+### Missing Critical Tasks
+
+No tasks are critically missing relative to the archetype and risk profile. The
+cli/library checklists surface the following gaps worth noting:
+
+- **Documented exit codes (3-tier)**: Partially missing — critic-002. Resolvable in T004 authoring.
+- **PyYAML direct dependency declaration**: Missing from T001 setup. Add a sub-task or amend T001.
+- **Semver regex enforcement in tests**: Missing from T018 as specified. Add during T018 implementation.
+- **Portability body-scan automated test**: Missing; T032 is manual-only. Add during T018 implementation.
+- **`markdownlint-cli2` version pinning**: Not in scope of this feature, but a CI risk. Note in T002.
+
+---
+
+### Metrics
+
+- **Showstopper count (effective):** 0
+- **Critical count (effective):** 0
+- **High count (effective):** 4 (critic-001, critic-002, critic-003, critic-004)
+- **Medium count (effective):** 4 (critic-005, critic-006, critic-007, critic-008)
+- **Findings by category:** cli\_ergonomics ×2, testing\_strategy ×2, api\_compatibility ×1, error\_handling\_resilience ×1, dependency\_supply\_chain ×1, missing-risk-profile ×1
+- **Missing operational tasks:** 2 minor (PyYAML dep declaration, semver regex test)
+
+---
+
+**VERDICT:** PROCEED
+
+All 8 findings resolved in spec.md, plan.md, and tasks.md before implementation.
+No required actions remain. Recommended risk mitigations (Assumption 2 and 4)
+are addressed via T006 authoring scope in tasks.md.

--- a/.documentation/specs/003-add-first-skill/plan.md
+++ b/.documentation/specs/003-add-first-skill/plan.md
@@ -1,0 +1,371 @@
+# Implementation Plan: Add First Agent Skill (write-spec)
+
+**Branch**: `003-add-first-skill` | **Date**: 2026-05-19 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `.documentation/specs/003-add-first-skill/spec.md`
+
+## Rationale Summary
+
+### Core Problem
+
+DevSpark's 28 `/devspark.*` slash-command prompts use a DevSpark-specific
+frontmatter contract (`handoffs`, `scripts`, `classification`) that is not
+interoperable with the open Agent Skills standard. DevSpark capabilities cannot
+be discovered, loaded, or executed by skills-compatible clients without bespoke
+DevSpark tooling.
+
+### Decision Summary
+
+Ship one portable, standalone skill — `write-spec` — that complies with the
+open Agent Skills specification, and refactor `/devspark.specify` to delegate
+spec-drafting to that skill via a well-defined adapter contract. Existing
+user-facing slash-command UX remains stable; the architectural change is
+internal.
+
+### Key Drivers
+
+- **Interoperability**: Make at least one DevSpark capability portable to any
+  skills-compatible client without DevSpark installation.
+- **Standards awareness**: Demonstrate first-class support for the open Agent
+  Skills spec (agentskills.io).
+- **Separation of concerns**: Establish the
+  `command → adapter → skill → context scripts → agent reasoning → artifact`
+  boundary that DevSpark's governance model requires.
+
+### Source Inputs
+
+- Open Agent Skills spec: <https://agentskills.io/specification>
+- Reference repo: <https://github.com/agentskills/agentskills>
+- Existing command: `templates/commands/specify.md`
+- Shared contract: `templates/spec-validation-contract.md`
+- Constitution v1.3.0: `.documentation/memory/constitution.md`
+- Clarifications session 2026-05-19 (recorded in spec.md)
+
+### Tradeoffs Considered
+
+- Option A — Replace slash-command surface with Agent Skills directly: rejected.
+  Breaks §I Backward Compatibility; reframes DevSpark as a skills framework.
+- Option B — Ship skill standalone with no command integration: rejected. Fails
+  to demonstrate the `command → invokes → skill` architectural value.
+- Option C — Auto-generate skills from all 28 commands: rejected. Premature
+  dual-maintenance burden.
+- Option D — Make `write-spec` orchestrate full spec + plan + tasks: rejected
+  for this feature. Smallest credible orchestration first.
+- **Selected** — Single portable `write-spec` skill + adapter contract + thin
+  command refactor: validates the dual-surface model end-to-end on one
+  high-value capability before scaling.
+
+### Architectural Impact
+
+- New top-level directory `templates/skills/` parallel to `templates/commands/`.
+- New contract files: `templates/skills/ADAPTER-contract.md`,
+  `templates/skills/SKILL-validation-contract.md`.
+- New skill: `templates/skills/write-spec/` (SKILL.md + scripts/ + references/).
+- New tests: `tests/test_skill_contract.py`, `tests/test_adapter_contract.py`.
+- New CLI command group: `devspark skills list` and `devspark skills validate`.
+- Thin refactor: `templates/commands/specify.md` delegates drafting to the skill.
+- No changes to the other 27 `/devspark.*` commands.
+- No changes to any `.documentation/` user artifacts in installed repos.
+
+### Reviewer Guidance
+
+1. **Adapter contract clarity (2A)**: Does it cleanly separate skill
+   responsibility (portable reasoning) from command responsibility (DevSpark
+   lifecycle)?
+2. **Skill portability (2B)**: Does `SKILL.md` frontmatter contain no
+   DevSpark-only keys? Is the body within budget?
+3. **Context engineering (2B)**: Does the skill demonstrate structured context
+   gathering on top of bare prompt delivery?
+4. **Refactor parity (2D)**: Does the existing test suite pass unchanged after
+   the command becomes a thin wrapper?
+5. **Scope discipline**: Exactly one skill (`write-spec`, spec-drafting only).
+
+## Summary
+
+Introduce the `templates/skills/` surface and one portable pilot skill
+(`write-spec`) that extracts the spec-drafting logic currently embedded in
+`templates/commands/specify.md`. Refactor `specify.md` to delegate drafting to
+the skill via a new adapter contract. Add CLI commands and tests that validate
+skill and adapter contract compliance on every PR.
+
+## Technical Context
+
+**Language/Version**: Python 3.11+ (CLI code), Markdown (skill/contract files),
+PowerShell 5.1+ and Bash (context-gathering scripts)
+
+**Primary Dependencies**: typer, rich, click (CLI); PyYAML>=6.0 (skill
+frontmatter parsing in tests and CLI — confirmed direct dependency in
+pyproject.toml, critic-006 resolved); pytest (test suite)
+
+**Storage**: File system only. Skill artifacts land in `templates/skills/`;
+spec outputs land in `.documentation/specs/`.
+
+**Testing**: pytest (existing suite extended). Two new test modules:
+`test_skill_contract.py` and `test_adapter_contract.py`.
+
+**Target Platform**: Portable Markdown (skill) + cross-platform scripts
+(PowerShell + Bash); CLI runs on Linux/macOS/Windows per existing constraints.
+
+**Project Type**: CLI tool + Markdown template framework
+
+**Performance Goals**: Not applicable for this feature; validation CLI should
+complete in < 5 s per skill on typical developer hardware.
+
+**Constraints**: §I Backward Compatibility (27 other commands unchanged),
+§III Ownership Boundary (no `.documentation/` writes by framework),
+§VI Platform Parity (dual PowerShell + Bash scripts), §VIII Markdown Quality
+(zero markdownlint errors on all new and modified Markdown).
+
+**Scale/Scope**: 1 new skill, 2 new contract files, 1 new skills guide
+reference, 2 new test files, 1 new CLI subcommand group, 1 command refactor.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Notes |
+| --------- | ------ | ----- |
+| §I Backward Compatibility | PASS | Only `specify.md` is refactored; 27 other commands unchanged. User-observable behavior preserved per SC-003. |
+| §II Explicit Over Implied | PASS | Adapter contract documents all responsibility boundaries explicitly; no silent scope inference. |
+| §III Ownership Boundary | PASS | No framework writes to `.documentation/` user artifacts. Skill ships under `templates/skills/`. |
+| §IV Governance Authority | PASS | Constitution authority remains repo-wide; new skill surface inherits all mandatory rules. |
+| §V Simplicity | PASS | Single skill, minimal adapter, no config layer. Complexity justified by interoperability goal with documented rejected simpler options. |
+| §VI Platform Parity | PASS | Context-gathering scripts supplied in both PowerShell and Bash per FR-009. |
+| §VII PR Review Artifact Commit Discipline | N/A | No PR review file involved in this feature's implementation commits. |
+| §VIII Markdown Quality | PASS | All new and modified Markdown gated by FR-018 (zero markdownlint errors). `ignores` block update required if any runtime output path is introduced. |
+
+**Gate result: PASS — proceed to Phase 0.**
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+.documentation/specs/003-add-first-skill/
+├── plan.md              ← this file
+├── research.md          ← Phase 0 output
+├── data-model.md        ← Phase 1 output
+├── contracts/           ← Phase 1 interface contracts
+├── checklists/
+│   └── requirements.md  ← created by /devspark.specify
+├── gates/               ← persisted gate artifacts from analyze/critic/checklist
+└── tasks.md             ← Phase 2 output (/devspark.tasks — not created here)
+```
+
+### Source Code (repository root)
+
+```text
+templates/skills/
+├── README.md                          ← 2A: new
+├── ADAPTER-contract.md                ← 2A: new
+├── SKILL-validation-contract.md       ← 2A: new
+├── references/
+│   └── devspark-skills-guide.md      ← 2A: complete existing stub
+└── write-spec/
+    ├── SKILL.md                       ← 2B: new
+    ├── references/                    ← 2B: new files
+    └── scripts/
+        ├── gather-context.ps1         ← 2B: new, PowerShell
+        └── gather-context.sh          ← 2B: new, Bash
+
+templates/commands/
+└── specify.md                         ← 2D: refactor (thin wrapper)
+
+src/devspark_cli/
+└── commands/
+    └── skills.py                      ← 2C: new CLI subcommand group
+
+tests/
+├── test_skill_contract.py             ← 2C: new
+└── test_adapter_contract.py           ← 2C: new
+
+README.md                              ← FR-019: update (dual-surface model)
+CLAUDE.md                              ← FR-019: update (positioning statement)
+```
+
+**Structure Decision**: Single project layout. `templates/skills/` is new and
+parallel to `templates/commands/`. CLI additions go in
+`src/devspark_cli/commands/skills.py`, following the existing pattern in
+`src/devspark_cli/commands/lifecycle.py`. No new top-level project directories
+are needed.
+
+## Complexity Tracking
+
+> No unjustified violations. All §V Simplicity concerns are addressed by the
+> single-skill, single-command-refactor scope with explicit tradeoff
+> documentation in spec.md.
+
+---
+
+## Phase 0: Research Findings
+
+*All NEEDS CLARIFICATION markers from the spec have been resolved (Clarifications
+session 2026-05-19). See `research.md` for full citations.*
+
+### Open Agent Skills frontmatter dialect
+
+- Decision: use `name`, `description`, and `metadata.version` (quoted semver)
+- DevSpark prohibits in `SKILL.md`: `handoffs`, `scripts` (command sense),
+  `classification`, `required_gates`, `recommended_next_step`, bare `version`
+- Rationale: upstream spec reserves `metadata` for additional properties while
+  keeping the top-level dialect portable; `metadata.version` is the stable hook
+
+### Context-gathering script scope for `write-spec`
+
+- Decision: constitution loading + prior-spec summary, JSON output format
+- Failure mode: emit partial JSON + `skipped_context` array; never block skill
+- Rejected: freeform exploration (non-deterministic, not demonstrable as context
+  engineering)
+
+### CLI command group shape
+
+- Decision: `devspark skills list` / `devspark skills validate [path]`
+- Consistent with existing `devspark harness` and `devspark adapter` groups
+- Exit non-zero on any failure per FR-013
+
+### Adapter contract responsibility split
+
+- Command: route classification, branch creation, multi-app scoping, artifact
+  path placement, checklist generation, gate enforcement
+- Skill: portable reasoning, context-gathering script execution, spec draft
+- Adapter: input mapping, output mapping, discovery path rules, parity rules
+
+### Phase sequencing (mandatory)
+
+- 2A before 2B: adapter contract stable before skill is built
+- 2B before 2C: skill exists before tests assert on it
+- 2C before 2D: test gate exists before command is refactored
+- 2D last: parity enforced by existing test suite throughout
+
+---
+
+## Phase 1: Design & Contracts
+
+### Data Model
+
+See [data-model.md](data-model.md) for full entity definitions.
+
+#### Skill Package (directory at `templates/skills/<skill-name>/`)
+
+| Field | Type | Constraint |
+| ----- | ---- | ---------- |
+| `name` | string | Max 64 chars; `[a-z0-9-]`; no leading/trailing/consecutive hyphens; matches parent dir |
+| `description` | string | 1–1024 chars; non-empty; discovery-rich |
+| `metadata.version` | quoted string | SemVer `"MAJOR.MINOR.PATCH"`; required for DevSpark skills |
+| `license` | string | Optional; upstream field |
+| `compatibility` | string | Optional; max 500 chars when present |
+| Body | Markdown | Max 500 lines / ~5000 tokens |
+
+Prohibited top-level keys in `SKILL.md`: `handoffs`, `scripts` (command sense),
+`classification`, `required_gates`, `recommended_next_step`, `version` (bare).
+
+#### Validation Result
+
+| Field | Type | Values |
+| ----- | ---- | ------ |
+| `skill_name` | string | from `name` frontmatter |
+| `skill_version` | string | from `metadata.version` |
+| `status` | enum | `pass`, `warn`, `fail` |
+| `findings` | list | each: `{rule, severity, message}` |
+
+Severity: `error` (validation fails), `warning` (advisory), `info`.
+
+#### Adapter Input Map
+
+| Command input | Skill context variable |
+| ------------- | ---------------------- |
+| User feature description | `$FEATURE_DESCRIPTION` |
+| Resolved constitution path | `$CONSTITUTION_PATH` |
+| Prior-spec summary (from script) | `$PRIOR_SPEC_SUMMARY` |
+
+Multi-app scope (`$APP_SCOPE`) is resolved by the command and is NOT passed
+into the skill body — multi-app scoping is a command-only responsibility.
+
+#### Adapter Output Map
+
+| Skill output | Command action |
+| ------------ | -------------- |
+| Draft `spec.md` body | Written to `SPEC_FILE` resolved by command |
+| `[NEEDS CLARIFICATION]` markers | Preserved; command may invoke `/devspark.clarify` |
+| `Assumptions` section | Preserved verbatim in placed spec |
+
+### Interface Contracts
+
+See [contracts/](contracts/) for full contract files.
+
+**contracts/skill-discovery.md** — The `write-spec` skill is discoverable via
+`templates/skills/write-spec/`. `devspark skills list` enumerates all sibling
+directories of `templates/skills/` that contain a `SKILL.md`. Clients load only
+`name` and `description` for indexing; full body is loaded on activation.
+
+**contracts/cli-commands.md** — Full CLI contract for `devspark skills list` and
+`devspark skills validate [path]`. Three-tier exit-code contract (critic-002):
+`pass` exits 0 with a one-line summary; `warn` exits 0 with warning count on
+stderr (body-budget pressure does not block CI); `fail` exits 1 with a
+`[RULE] [OFFENDING-VALUE] message` diagnostic on stderr. `skills list` output
+format is not yet stable for scripting (no `--json` flag in this release — see
+critic-007 decision).
+
+**contracts/adapter-contract.md** — Summary: command resolves skill path before
+invoking; command passes context as named variables per adapter contract; command
+places draft in DevSpark-governed artifact path; skill must not perform branch
+creation, multi-app resolution, or gate enforcement.
+
+---
+
+## Ordered Sub-Phases for /devspark.tasks
+
+Sub-phases must land in order (2A → 2B → 2C → 2D). Each sub-phase has a clear
+completion gate before the next begins.
+
+### Sub-phase 2A — Shared Skills Foundation
+
+**Completion gate**: `ADAPTER-contract.md` and `SKILL-validation-contract.md`
+both exist, `devspark-skills-guide.md` is complete, FR-002/FR-002a/FR-003
+satisfied.
+
+Files to deliver:
+
+1. `templates/skills/README.md`
+2. `templates/skills/SKILL-validation-contract.md`
+3. `templates/skills/ADAPTER-contract.md`
+4. `templates/skills/references/devspark-skills-guide.md` (complete existing)
+5. `README.md` update (FR-019 positioning statement + pointers)
+6. `CLAUDE.md` update (FR-019 dual-surface model)
+
+### Sub-phase 2B — Standalone `write-spec` Skill
+
+**Completion gate**: `templates/skills/write-spec/SKILL.md` exists and passes
+manual validation against `SKILL-validation-contract.md`; both context scripts
+run without error on current repo; FR-004 through FR-010 satisfied.
+
+Files to deliver:
+
+1. `templates/skills/write-spec/SKILL.md`
+2. `templates/skills/write-spec/references/` (at minimum: spec-template
+   reference, clarification format, success criteria guidelines)
+3. `templates/skills/write-spec/scripts/gather-context.ps1`
+4. `templates/skills/write-spec/scripts/gather-context.sh`
+
+### Sub-phase 2C — Tests and CLI
+
+**Completion gate**: `pytest tests/test_skill_contract.py tests/test_adapter_contract.py`
+passes; `devspark skills list` and `devspark skills validate` subcommands are
+wired into the CLI; deliberate-violation fixture confirms non-zero exit;
+FR-011 through FR-013 satisfied.
+
+Files to deliver:
+
+1. `tests/test_skill_contract.py`
+2. `tests/test_adapter_contract.py`
+3. `src/devspark_cli/commands/skills.py`
+4. Wiring: `_app.py` adds `skills_app` subcommand
+
+### Sub-phase 2D — Thin-Wrapper Command Refactor
+
+**Completion gate**: All existing tests under `tests/test_create_spec_workflow_integration.py`
+and related pass unchanged; `test_adapter_contract.py` confirms delegation;
+no user-observable behavior difference; FR-014 and FR-015 satisfied.
+
+Files to deliver:
+
+1. `templates/commands/specify.md` (refactored)

--- a/.documentation/specs/003-add-first-skill/spec.md
+++ b/.documentation/specs/003-add-first-skill/spec.md
@@ -1,6 +1,8 @@
 ---
 classification: full-spec
 risk_level: medium
+risk_profile: internal
+change_type: brownfield
 target_workflow: specify-full
 required_artifacts: spec, plan, tasks
 recommended_next_step: clarify

--- a/.documentation/specs/003-add-first-skill/spec.md
+++ b/.documentation/specs/003-add-first-skill/spec.md
@@ -1,0 +1,238 @@
+---
+classification: full-spec
+risk_level: medium
+target_workflow: specify-full
+required_artifacts: spec, plan, tasks
+recommended_next_step: clarify
+required_gates: checklist, analyze, critic
+---
+
+# Feature Specification: Add First Agent Skill (write-spec)
+
+**Feature Branch**: `003-add-first-skill`
+**Created**: 2026-05-19
+**Status**: Draft <!-- Valid: Draft | In Progress | Complete -->
+**Input**: User description: "Add Agent Skills support to DevSpark, starting with a write-spec skill that wraps /devspark.specify per the agentskills.io open spec"
+
+## Rationale Summary
+
+### Core Problem
+
+DevSpark's spec-driven workflows are exposed today only as 28 `/devspark.*` slash-command prompts under `templates/commands/`. Each prompt uses a DevSpark-specific frontmatter contract (`handoffs`, `scripts`, `classification`) that is not interoperable with the open **Agent Skills** standard (originally from Anthropic, now adopted by a growing list of agentic clients per agentskills.io). Consequently, DevSpark's procedural knowledge cannot be discovered, loaded, or executed by skills-compatible clients without bespoke DevSpark tooling — and there is no demonstration that DevSpark's value proposition (lifecycle orchestration, governance, context engineering) is *distinct from and complementary to* the emerging skills ecosystem.
+
+### Decision Summary
+
+Position DevSpark as a **lifecycle orchestration layer that hosts portable Agent Skills**, not as a skills framework. Ship one portable, standalone skill — `write-spec` — that complies with the open Agent Skills specification, and refactor the existing `/devspark.specify` command to invoke that skill via a well-defined adapter contract. Existing user-facing slash-command UX remains stable; the architectural change is internal.
+
+**Positioning statement** (for repo-level docs, FR-019):
+
+> DevSpark treats skills as portable capability packages within a governed lifecycle orchestration system. Commands invoke skills; DevSpark governs the lifecycle around them.
+
+### Key Drivers
+
+- **Interoperability**: Make at least one DevSpark capability portable to any skills-compatible client.
+- **Standards awareness**: Demonstrate first-class support for the open Agent Skills spec.
+- **Separation of concerns**: Establish the architectural boundary `command → adapter → skill → context-gathering scripts → agent reasoning → governed artifact placement`, which most skill ecosystems currently conflate.
+- **Context engineering as differentiator**: A skill in DevSpark is not just a prompt — it is a prompt plus deterministic, script-driven repository context gathering. This is the capability gap DevSpark fills above the bare skills layer.
+- **Constitution alignment**: Must be additive (§I Backward Compatibility), live in the framework payload not user docs (§III Ownership Boundary), justify added complexity (§V Simplicity), preserve script parity (§VI), and pass markdownlint (§VIII).
+
+### Source Inputs
+
+- Agent Skills specification: <https://agentskills.io/specification>
+- Reference repository: <https://github.com/agentskills/agentskills>
+- Existing DevSpark command contract: `templates/commands/specify.md`, `templates/spec-validation-contract.md`
+- DevSpark Constitution v1.3.0: `.documentation/memory/constitution.md`
+- Tactical guidance reviewed in feature kickoff (recorded in Clarifications session 2026-05-19)
+
+### Tradeoffs Considered
+
+- **Option A — Replace slash-command surface with Agent Skills directly**: rejected. Breaks §I Backward Compatibility and reframes DevSpark *as* a skills framework rather than an orchestrator of skills.
+- **Option B — Ship the skill standalone with no integration into existing commands**: rejected. Fails to demonstrate the architectural value (`command → invokes → skill`) that distinguishes DevSpark from a prompt collection.
+- **Option C — Auto-generate skills from all 28 commands in one pass**: rejected. Premature commitment, immediate dual-maintenance burden, encourages "prompt collection syndrome" and "tiny-skill fragmentation."
+- **Option D — Make `write-spec` orchestrate the full spec + plan + tasks lifecycle**: rejected for this feature (deferred). Smallest credible orchestration first; expand later if the model holds.
+- **Selected — Single portable skill (`write-spec`, spec-drafting only) + adapter contract + thin-command refactor**: validates the dual-surface model end-to-end on one high-value capability before scaling.
+
+### Architectural Impact
+
+This feature introduces a four-phase internal restructure for the `specify` capability while preserving the user-facing command:
+
+| Sub-phase | Deliverable | Touches |
+|-----------|-------------|---------|
+| 2A | **Shared skills foundations** documenting DevSpark skill conventions and how a DevSpark command invokes a skill (input mapping, output mapping, governance hooks) | `templates/skills/SKILL-validation-contract.md`, `templates/skills/ADAPTER-contract.md`, `templates/skills/references/devspark-skills-guide.md` |
+| 2B | **Standalone `write-spec` skill** (`templates/skills/write-spec/SKILL.md` + `references/` + paired PowerShell/Bash `scripts/` for context gathering) that is portable to any skills-compatible client | `templates/skills/write-spec/**` |
+| 2C | **Test suite** enforcing skill validation contract + adapter contract on every PR | `tests/test_skill_contract.py`, `tests/test_adapter_contract.py` |
+| 2D | **Thin-wrapper refactor** of `templates/commands/specify.md` so the command performs DevSpark-specific lifecycle work (routing, branch creation, artifact placement, gating) and delegates the spec-drafting itself to the `write-spec` skill | `templates/commands/specify.md` |
+
+Sub-phases must land in order (2A → 2B → 2C → 2D) so the adapter contract is stable before the skill is built, the test gate exists before the command refactor, and behavior parity for the command can be enforced by the existing `/devspark.specify` test suite throughout.
+
+Other architectural notes:
+
+- New top-level directory `templates/skills/` parallel to `templates/commands/`, `templates/prompts/`, `templates/workflows/`.
+- New CLI subcommand surface for listing and validating skills, parallel to existing CLI patterns in `src/devspark_cli/`.
+- No changes to user `.documentation/` artifacts in installed repos (§III Ownership Boundary).
+- The other 27 `/devspark.*` commands are unchanged by this feature.
+
+### Reviewer Guidance
+
+Reviewers should focus on:
+
+1. **Adapter contract clarity** (2A): does it cleanly separate skill responsibility (portable reasoning) from command responsibility (DevSpark-specific lifecycle: branch creation, artifact placement, gating, multi-app scoping)? Could a *different* skills-compatible client execute the skill standalone without any DevSpark code?
+2. **Skill portability** (2B): does `SKILL.md` strictly use the open Agent Skills frontmatter dialect (no DevSpark-only keys leaking in)? Is the body ≤500 lines? Are bundled context-gathering scripts self-contained and dual-parity (PowerShell + Bash) per §VI?
+3. **Context-engineering surface** (2B): does the skill demonstrate that DevSpark contributes structured context gathering (repository inspection, prior-spec lookup, constitution loading) on top of a bare prompt — not just prompt engineering?
+4. **Refactor parity** (2D): does the existing `/devspark.specify` test suite still pass unchanged after the command becomes a thin wrapper? Are there any user-observable behavior differences?
+5. **Scope discipline**: this feature delivers ONE skill (`write-spec`, spec-drafting only). Reviewers should reject any attempt to expand to `plan` or `tasks` skills inside this feature.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Portable skill executes in a non-DevSpark client (Priority: P1)
+
+A developer using a skills-compatible agent client (Claude Code, Cursor, or any other client listed on the agentskills.io Client Showcase) that has **no DevSpark installation** loads the `templates/skills/write-spec/` folder. The client surfaces the skill in its discovery list. The developer asks the agent to "draft a feature spec for X." The agent activates the skill, runs any bundled context-gathering scripts, and produces a draft `spec.md` artifact that conforms to the shared spec validation contract.
+
+**Why this priority**: This is the interoperability proof. Without it, the open-spec compliance has no observable user value and the "portable capability package" positioning is unsubstantiated.
+
+**Independent Test**: Copy only `templates/skills/write-spec/` into a fresh workspace without DevSpark CLI installed, load it into a skills-compatible client per its standard installation flow, request a draft spec for a sample feature description, and verify the produced `spec.md` conforms to `templates/spec-validation-contract.md`.
+
+**Acceptance Scenarios**:
+
+1. **Given** a skills-compatible client has loaded the `write-spec` skill with no DevSpark CLI present, **When** the user asks the agent to draft a spec for a feature, **Then** the agent activates the skill (visible in its activation trace) and produces a draft `spec.md` with valid route-metadata frontmatter, the four mandatory full-spec sections, a `Draft` status line, and no more than three `[NEEDS CLARIFICATION]` markers.
+2. **Given** the skill is loaded at startup, **When** the agent enumerates available skills, **Then** only the skill's `name` and `description` are loaded into context (progressive disclosure); the full body is loaded only on activation.
+3. **Given** the skill's `SKILL.md` frontmatter, **When** it is parsed by an open-spec validator, **Then** it contains no DevSpark-specific keys (e.g., `handoffs`, `scripts:` in the command-prompt sense) and complies with the open Agent Skills spec.
+
+### User Story 2 - DevSpark command invokes the skill internally (Priority: P1)
+
+A user runs `/devspark.specify "..."` inside a DevSpark-enabled repository. The command performs DevSpark-specific lifecycle work (route classification, branch creation, multi-app scoping, artifact placement, checklist generation, gate enforcement) and delegates the actual spec-drafting reasoning to the `write-spec` skill via the documented adapter contract. The user observes **no behavior change** compared to the pre-refactor `/devspark.specify`.
+
+**Why this priority**: This is the architectural proof. Without it, the skill is a sidecar; with it, the `command → invokes → skill` model is real and reusable.
+
+**Independent Test**: Run the existing `/devspark.specify` test suite (`tests/test_create_spec_workflow_integration.py` and related) against the refactored command. All tests must pass unchanged. Additionally, the adapter test (`tests/test_adapter_contract.py`) must verify the command actually delegates to the skill rather than reimplementing the drafting logic.
+
+**Acceptance Scenarios**:
+
+1. **Given** the refactored `/devspark.specify` and the `write-spec` skill, **When** a user issues `/devspark.specify "Add user auth"`, **Then** the resulting artifacts (`spec.md`, `checklists/requirements.md`, branch creation, frontmatter) are structurally equivalent to what the pre-refactor command would have produced.
+2. **Given** the adapter contract, **When** the adapter test runs, **Then** it confirms the command file references the skill and does not duplicate the drafting procedure inline.
+3. **Given** a DevSpark multi-app repository, **When** a user issues `/devspark.specify --app <id> "..."`, **Then** the command resolves the app scope and the skill receives the correctly scoped paths via the adapter — multi-app scoping remains a command responsibility, not a skill responsibility.
+
+### User Story 3 - Maintainer validates a skill before merging (Priority: P2)
+
+A DevSpark contributor adds or edits a skill in `templates/skills/`. They run a single CLI command to validate the skill against both the open Agent Skills spec, the DevSpark skill-validation addendum, and the adapter contract. CI runs the same validation on every PR.
+
+**Why this priority**: Without enforced validation, skills will drift from the open spec, from DevSpark conventions, and from the adapter contract — eroding the interop guarantee that motivates the feature.
+
+**Independent Test**: Introduce a deliberate violation (uppercase letter in `name`, `description` over 1024 chars, missing required body section, or a command that references a non-existent skill) into a fixture; verify the CLI command and the test suite both fail with a precise error message naming the violated rule.
+
+**Acceptance Scenarios**:
+
+1. **Given** a skill folder with a valid `SKILL.md`, **When** the validation CLI command is run, **Then** it exits zero with a one-line summary including skill name and version.
+2. **Given** any rule violation, **When** the validation CLI command is run, **Then** it exits non-zero with a human-readable diagnostic naming the violated rule and offending value.
+3. **Given** any pull request that adds or modifies files under `templates/skills/` or under `templates/commands/specify.md`, **When** CI runs, **Then** the skill validation test AND the adapter contract test both gate merge.
+
+### Edge Cases
+
+- **Name/directory mismatch**: A skill's frontmatter `name` does not match its parent directory name. Validation MUST fail with a clear diagnostic per the open spec.
+- **Body length budget exceeded**: A `SKILL.md` body exceeds the recommended 500-line / ~5000-token budget. Validation MUST warn and recommend moving detail into `references/`.
+- **Markdownlint violations**: A new `SKILL.md` fails the repo-wide markdownlint job. Per §VIII this MUST block merge.
+- **Multi-app scoping**: A user invokes `/devspark.specify --app <id>` in a multi-app repository. Multi-app resolution MUST remain a command responsibility (not pushed into the skill), since multi-app scoping is a DevSpark-specific governance concern.
+- **Source-command drift**: The skill body is updated but `templates/commands/specify.md` is not (or vice versa). The adapter contract test MUST detect drift (e.g., command delegates to a skill version that no longer exposes the expected interface).
+- **Bundled-script parity**: The skill bundles executable code under `scripts/`; both PowerShell and Bash variants MUST exist per §VI.
+- **Conflicting frontmatter dialects**: DevSpark command frontmatter keys (`handoffs`, `scripts`, `classification`) MUST NOT appear in `SKILL.md`. Conversely, open Agent Skills frontmatter fields beyond what the adapter contract reads SHOULD NOT appear in `templates/commands/`.
+- **Skill executed in a non-DevSpark client**: When invoked outside DevSpark, the skill MUST still produce a valid `spec.md` artifact in the user's current working directory — but it MUST NOT attempt DevSpark-specific operations (branch creation, multi-app resolution, gate enforcement). Graceful degradation, not failure.
+- **Context-gathering script unavailable**: If a context-gathering script under the skill's `scripts/` cannot run (e.g., not in a git repo, required tool missing), the skill MUST proceed with reduced context and surface what was skipped in the produced spec's Assumptions section — never silently fail.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+#### Phase 2A — Adapter Contract
+
+- **FR-001**: The repository MUST contain `templates/skills/ADAPTER-contract.md` defining how a DevSpark command invokes an Agent Skill. The contract MUST specify: (a) skill discovery (path resolution rules), (b) input mapping (how command arguments and resolved context are passed to the skill), (c) output mapping (how skill-produced artifacts are placed into DevSpark-governed paths), (d) responsibility split (which concerns belong to the command vs. the skill), and (e) backward-compatibility rules (how command behavior parity is preserved across a skill refactor).
+- **FR-002**: The repository MUST contain `templates/skills/SKILL-validation-contract.md` defining (a) the open Agent Skills frontmatter rules (name/description/length limits), (b) DevSpark addendum rules (required `metadata.version`, required body sections, body-length budget, mandatory back-reference to a source command when one exists, prohibited frontmatter keys), and (c) repair rules consistent with `templates/spec-validation-contract.md` style.
+- **FR-002a**: The repository MUST contain `templates/skills/references/devspark-skills-guide.md` as the shared contributor guide for DevSpark skills. The guide MUST summarize the upstream Agent Skills rules and DevSpark-specific conventions for repository layout, command-vs-skill ownership, context engineering, script parity, validation surfaces, and adding future skills.
+- **FR-003**: The adapter contract MUST explicitly assign DevSpark-specific lifecycle concerns (route classification, branch creation, multi-app scoping, artifact path placement, checklist generation, gate enforcement) to the **command**, and reasoning/drafting concerns to the **skill**.
+
+#### Phase 2B — Standalone `write-spec` Skill
+
+- **FR-004**: The repository MUST contain a `write-spec` skill at `templates/skills/write-spec/SKILL.md` whose frontmatter strictly complies with the open Agent Skills specification (valid `name` matching the directory, non-empty `description` within length limits) and contains no DevSpark-only frontmatter keys.
+- **FR-004a**: Every DevSpark-managed skill under `templates/skills/` MUST declare its version in `metadata.version` using a quoted semantic-version string. Top-level `version` frontmatter MUST NOT be used.
+- **FR-005**: The `write-spec` skill's `description` MUST be discovery-rich, naming both *what* the skill does and *when* to use it, including the keywords commonly used to request a spec (draft specification, feature spec, requirements document, user stories, acceptance criteria).
+- **FR-006**: The `write-spec` skill body MUST instruct the agent to perform the spec-drafting workflow: load context (constitution, prior specs, relevant repo conventions when available), draft the spec against the shared validation contract, limit `[NEEDS CLARIFICATION]` markers to a maximum of three, and start the spec in `Draft` status.
+- **FR-007**: The `write-spec` skill body MUST stay within the recommended budget (≤ 500 lines / ~5000 tokens); longer material MUST be moved under `templates/skills/write-spec/references/`.
+- **FR-008**: The `write-spec` skill MUST demonstrate **context engineering** as a first-class concern by bundling minimal context-gathering scripts under `templates/skills/write-spec/scripts/`. The scripts MUST produce structured context for constitution loading and prior-spec summary at minimum. The skill MUST NOT rely solely on the agent's freeform repository exploration.
+- **FR-009**: The `write-spec` skill's bundled context-gathering scripts MUST provide equivalent PowerShell and Bash variants (§VI Platform Parity).
+- **FR-010**: The `write-spec` skill MUST degrade gracefully when invoked outside a DevSpark-enabled repository: it MUST still produce a valid `spec.md` artifact, MUST NOT attempt DevSpark-specific operations (branch creation, multi-app scoping), and MUST record skipped context in the produced spec's Assumptions section.
+
+#### Phase 2C — Tests
+
+- **FR-011**: The repository MUST include automated tests under `tests/` that enforce the skill validation contract on every skill folder present in `templates/skills/`, gating PR merge.
+- **FR-012**: The repository MUST include an adapter contract test that verifies (a) `templates/commands/specify.md` references the `write-spec` skill, (b) the command does not duplicate the drafting procedure inline, and (c) the existing `/devspark.specify` integration tests still pass against the refactored command.
+- **FR-013**: The repository MUST expose a plural CLI command group for skills: `devspark skills list` to enumerate skills found under `templates/skills/`, and `devspark skills validate [path]` to validate all skills or one supplied skill path. Validation MUST return a non-zero exit code on any failure.
+
+#### Phase 2D — Thin-Wrapper Command Refactor
+
+- **FR-014**: `templates/commands/specify.md` MUST be refactored so that DevSpark-specific lifecycle work (route classification, branch creation, multi-app scoping, artifact placement, checklist generation, gate enforcement) remains in the command, and the spec-drafting reasoning is delegated to the `write-spec` skill via the adapter contract.
+- **FR-015**: After the refactor, the existing `/devspark.specify` integration test suite MUST pass unchanged. User-observable behavior (artifacts produced, branch naming, frontmatter, checklist contents) MUST be equivalent in structure to the pre-refactor command.
+
+#### Cross-Cutting
+
+- **FR-016**: The other 27 `/devspark.*` commands MUST NOT be modified by this feature; the change is scoped to `specify` only (§I Backward Compatibility).
+- **FR-017**: The repository MUST NOT install, modify, or remove any file under any `.documentation/` directory as a result of adopting skills (§III Ownership Boundary).
+- **FR-018**: All new and modified markdown introduced by this feature MUST pass `npx markdownlint-cli2 "**/*.md"` with zero errors (§VIII).
+- **FR-019**: Repository-level documentation (`README.md` and `CLAUDE.md`) MUST be updated with: (a) the positioning statement from Rationale Summary, (b) a description of the dual-surface model (commands ↔ skills) and the `command → invokes → skill` internal architecture, and (c) pointers to `templates/skills/README.md`, `SKILL-validation-contract.md`, `ADAPTER-contract.md`, and `templates/skills/references/devspark-skills-guide.md`.
+- **FR-020**: The distribution surface for the skill MUST be in-repo only for this release. The `write-spec` skill MUST ship under `templates/skills/write-spec/`; publication to an external index (for example, agentskills.io Client Showcase or a community registry) is explicitly deferred.
+
+### Key Entities
+
+- **Skill**: A versioned folder under `templates/skills/<skill-name>/` that packages a single agent capability per the open Agent Skills specification. Portable; can run in any skills-compatible client without DevSpark.
+- **SKILL.md**: The required entry point of a skill — YAML frontmatter (open-spec fields only) plus Markdown body of agent instructions.
+- **Skill Version**: A quoted semantic-version string stored at `metadata.version` in `SKILL.md`. DevSpark validation reports the skill name and this version; top-level `version` is prohibited.
+- **Command**: A `/devspark.*` slash-command prompt under `templates/commands/`. Owns DevSpark-specific lifecycle and governance concerns. After this feature, `specify` invokes a skill for the reasoning portion.
+- **Adapter Contract**: The DevSpark-authored document defining the boundary between commands and skills (responsibilities, input/output mapping, discovery, backward-compatibility rules).
+- **Skill Validation Contract**: The DevSpark-authored document defining the rules every `SKILL.md` and skill folder must satisfy, layered on top of upstream open-spec rules.
+- **DevSpark Skills Guide**: The shared contributor reference at `templates/skills/references/devspark-skills-guide.md` that explains how this repository designs, organizes, validates, and reviews skills.
+- **Context-Gathering Script**: Deterministic, dual-parity (PowerShell + Bash) code under a skill's `scripts/` directory that prepares structured repository context for the agent before reasoning. For `write-spec`, this includes constitution loading and prior-spec summary at minimum. The DevSpark-distinctive contribution above bare prompt engineering.
+- **Skill Validation Result**: Structured pass/warn/fail output from the validation CLI and test suite, used by humans and CI to gate merges.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A spec-drafting task that previously required a DevSpark-native client can be completed end-to-end in any skills-compatible client by loading only the `templates/skills/write-spec/` folder — with **zero** DevSpark-specific configuration required in the host client.
+- **SC-002**: 100% of skill folders under `templates/skills/` pass the skill validation contract in CI on the default branch; any contract violation blocks merge.
+- **SC-003**: After the Phase 2D refactor, 100% of the existing `/devspark.specify` integration tests pass unchanged — confirming structural behavior parity for DevSpark users.
+- **SC-004**: All markdown introduced or modified by the feature produces zero markdownlint errors on the feature PR's required CI lint job.
+- **SC-005**: A new contributor following only `templates/skills/README.md`, the adapter contract, and the `write-spec` example can produce a second skill folder + thin-wrapper command that passes both the skill validation and adapter contract tests on their first PR attempt.
+- **SC-006**: Existing DevSpark users observe zero regressions in any `/devspark.*` slash-command behavior (verified by the existing test suite passing unchanged) — the new surface is strictly additive and the `specify` refactor is observably transparent.
+- **SC-007**: The `write-spec` skill, when invoked, produces a structured context payload (constitution summary + prior-spec summary at minimum) that is verifiable in its execution trace — demonstrating context engineering, not just prompt delivery.
+
+## Assumptions
+
+- The open Agent Skills specification at <https://agentskills.io/specification> remains stable in the fields used by this feature.
+- Skills-compatible clients of interest respect progressive disclosure, making the body-length budget meaningful.
+- Behavior parity for `/devspark.specify` after the Phase 2D refactor can be enforced by the existing integration test suite without writing new behavioral tests beyond the adapter contract test.
+- The pilot skill bundles minimal context-gathering scripts for constitution loading and prior-spec summary under `scripts/`, accepting the §VI Platform Parity obligation for those scripts as a deliberate demonstration of context engineering.
+- DevSpark skill versioning uses `metadata.version` because the upstream Agent Skills specification reserves `metadata` for additional key-value properties while keeping the top-level frontmatter dialect stable.
+- Drift between the skill body and the thin-wrapper command can be detected mechanically by the adapter contract test; full code-generation between the two surfaces is not required.
+
+## Out of Scope
+
+- Conversion of any command other than `/devspark.specify` to a skill in this feature (`plan`, `tasks`, `implement`, etc. are deferred).
+- Expansion of `write-spec` to orchestrate plan/tasks generation (deferred; see Tradeoffs Option D).
+- The DevSpark AI Taxonomy document (Skill / Agent / Command / Workflow / Shim / Context Engineering / Lifecycle / Orchestrator). Deferred to a follow-up feature; the positioning statement and adapter contract in this feature provide enough conceptual scaffolding for the pilot.
+- Publishing skills to any external registry beyond shipping them inside the DevSpark repository. External publication is deferred to a follow-up feature after the in-repo pilot proves the model.
+- Generating skills automatically from existing `templates/commands/*.md` prompts.
+- Changes to any of the other 27 `/devspark.*` slash commands.
+- Changes to user `.documentation/` artifacts in installed repositories (forbidden by §III).
+- Adoption of the experimental `allowed-tools` open-spec field (deferred until upstream stabilization).
+
+## Clarifications
+
+### Session 2026-05-19
+
+- Q: Should the skill body be a thin wrapper that delegates to `/devspark.specify`, or a fully self-contained portable capability? → A: **Fully self-contained, portable.** Skills are portable capability packages; commands invoke them. Resolved via the Phase 2A–2D architecture.
+- Q: Should this feature deliver only `write-spec`, or also `plan` and `tasks` skills? → A: **Only `write-spec`, spec-drafting only.** Smallest credible orchestration first. Plan/tasks deferred.
+- Q: Should the `command → invokes → skill` pivot be implemented in this feature or deferred? → A: **Implemented in this feature, sequenced as sub-phases 2A → 2B → 2C → 2D** (adapter contract → standalone skill → tests → thin-wrapper command refactor).
+- Q: Should the DevSpark AI Taxonomy doc be in scope? → A: **Deferred** to a follow-up feature. Positioning statement (in Rationale Summary, FR-019) is sufficient conceptual scaffolding for this pilot.
+- Q: In addition to shipping inside the DevSpark repo, should this feature publish the skill to an external index? → A: **In-repo distribution only for this release.** External publication is deferred until after the pilot proves the model.
+- Q: What CLI shape should skill list and validation commands use? → A: **Use a plural `skills` command group:** `devspark skills list` and `devspark skills validate [path]`.
+- Q: Should the `write-spec` skill bundle context-gathering scripts or only document host-provided context? → A: **Bundle minimal dual-script context loaders** for constitution loading and prior-spec summary.
+- Q: Where should DevSpark-managed skills declare their version? → A: **Require `metadata.version`** as a quoted semantic-version string; top-level `version` is prohibited.
+- Q: Should `templates/skills/references/devspark-skills-guide.md` be a required deliverable or only a helper reference? → A: **Required Phase 2A deliverable** for shared DevSpark skills guidance.

--- a/.documentation/specs/003-add-first-skill/spec.md
+++ b/.documentation/specs/003-add-first-skill/spec.md
@@ -13,7 +13,7 @@ required_gates: checklist, analyze, critic
 
 **Feature Branch**: `003-add-first-skill`
 **Created**: 2026-05-19
-**Status**: Draft <!-- Valid: Draft | In Progress | Complete -->
+**Status**: Complete <!-- Valid: Draft | In Progress | Complete -->
 **Input**: User description: "Add Agent Skills support to DevSpark, starting with a write-spec skill that wraps /devspark.specify per the agentskills.io open spec"
 
 ## Rationale Summary
@@ -86,7 +86,7 @@ Reviewers should focus on:
 
 ## User Scenarios & Testing *(mandatory)*
 
-### User Story 1 - Portable skill executes in a non-DevSpark client (Priority: P1)
+### User Story 1 - Portable skill executes in a non-DevSpark client (Priority: P1) ✅ Complete
 
 A developer using a skills-compatible agent client (Claude Code, Cursor, or any other client listed on the agentskills.io Client Showcase) that has **no DevSpark installation** loads the `templates/skills/write-spec/` folder. The client surfaces the skill in its discovery list. The developer asks the agent to "draft a feature spec for X." The agent activates the skill, runs any bundled context-gathering scripts, and produces a draft `spec.md` artifact that conforms to the shared spec validation contract.
 
@@ -100,7 +100,7 @@ A developer using a skills-compatible agent client (Claude Code, Cursor, or any 
 2. **Given** the skill is loaded at startup, **When** the agent enumerates available skills, **Then** only the skill's `name` and `description` are loaded into context (progressive disclosure); the full body is loaded only on activation.
 3. **Given** the skill's `SKILL.md` frontmatter, **When** it is parsed by an open-spec validator, **Then** it contains no DevSpark-specific keys (e.g., `handoffs`, `scripts:` in the command-prompt sense) and complies with the open Agent Skills spec.
 
-### User Story 2 - DevSpark command invokes the skill internally (Priority: P1)
+### User Story 2 - DevSpark command invokes the skill internally (Priority: P1) ✅ Complete
 
 A user runs `/devspark.specify "..."` inside a DevSpark-enabled repository. The command performs DevSpark-specific lifecycle work (route classification, branch creation, multi-app scoping, artifact placement, checklist generation, gate enforcement) and delegates the actual spec-drafting reasoning to the `write-spec` skill via the documented adapter contract. The user observes **no behavior change** compared to the pre-refactor `/devspark.specify`.
 
@@ -114,7 +114,7 @@ A user runs `/devspark.specify "..."` inside a DevSpark-enabled repository. The 
 2. **Given** the adapter contract, **When** the adapter test runs, **Then** it confirms the command file references the skill and does not duplicate the drafting procedure inline.
 3. **Given** a DevSpark multi-app repository, **When** a user issues `/devspark.specify --app <id> "..."`, **Then** the command resolves the app scope and the skill receives the correctly scoped paths via the adapter — multi-app scoping remains a command responsibility, not a skill responsibility.
 
-### User Story 3 - Maintainer validates a skill before merging (Priority: P2)
+### User Story 3 - Maintainer validates a skill before merging (Priority: P2) ✅ Complete
 
 A DevSpark contributor adds or edits a skill in `templates/skills/`. They run a single CLI command to validate the skill against both the open Agent Skills spec, the DevSpark skill-validation addendum, and the adapter contract. CI runs the same validation on every PR.
 

--- a/.documentation/specs/003-add-first-skill/tasks.md
+++ b/.documentation/specs/003-add-first-skill/tasks.md
@@ -1,0 +1,472 @@
+---
+description: "Task list for feature 003-add-first-skill"
+---
+
+# Tasks: Add First Agent Skill (write-spec)
+
+**Input**: Design documents from `.documentation/specs/003-add-first-skill/`
+**Prerequisites**: plan.md ✓, spec.md ✓, checklists/requirements.md ✓
+**Tests**: Test tasks included — required by spec (FR-011, FR-012, SC-002, SC-003).
+
+**Organization**: Tasks grouped by sub-phase (2A → 2B → 2C → 2D, mandatory order)
+then by user story within each sub-phase.
+
+## Rationale Summary
+
+### Core Problem
+
+DevSpark's `/devspark.*` slash-command prompts use a DevSpark-specific frontmatter
+contract that is not interoperable with the open Agent Skills standard. No DevSpark
+capability can be discovered or executed by skills-compatible clients without
+bespoke DevSpark tooling.
+
+### Decision Summary
+
+Ship one portable pilot skill (`write-spec`) that complies with the open Agent
+Skills specification. Refactor `/devspark.specify` to delegate spec-drafting to
+that skill via a documented adapter contract. Add CLI validation and tests that
+gate skill contract compliance on every PR.
+
+### Key Drivers
+
+- Interoperability: any skills-compatible client can load and run `write-spec`
+  with zero DevSpark-specific configuration.
+- Standards awareness: demonstrate first-class support for agentskills.io.
+- Context engineering as differentiator: the skill ships with deterministic
+  dual-parity context-gathering scripts, not just prompt text.
+
+### Reviewer Guidance
+
+- Check adapter contract clarity (2A) before reviewing the skill (2B).
+- Confirm `SKILL.md` has no DevSpark-only frontmatter keys (2B).
+- Verify existing integration tests pass unchanged after the command refactor (2D).
+- Scope discipline: exactly one skill (`write-spec`, spec-drafting only).
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no shared state dependencies)
+- **[Story]**: User story: [US1], [US2], [US3]
+- File paths are absolute from repository root
+
+## Path Conventions
+
+Single project layout. Skills surface under `templates/skills/`. CLI under
+`src/devspark_cli/commands/`. Tests under `tests/`.
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Confirm directory skeleton exists and markdownlint baseline is green
+before authoring any new files.
+
+- [ ] T001 Verify `templates/skills/` directory exists with `write-spec/` and
+  `references/` subdirectories; create any missing directories; confirm
+  `PyYAML>=6.0` is present as a direct dependency in `pyproject.toml`
+  (critic-006 — already declared; verification step ensures it stays explicit
+  if lockfile is regenerated)
+- [ ] T002 [P] Run `npx markdownlint-cli2 "**/*.md"` from repo root and confirm
+  zero errors as the baseline before new files are added
+- [ ] T003 [P] Confirm existing test suite passes: `pytest tests/` (establishes
+  regression baseline before any code changes)
+
+---
+
+## Phase 2: Foundational (Sub-phase 2A — Shared Skills Foundation)
+
+**Purpose**: Contract files and shared guide must exist and be stable before the
+skill body (2B), the tests (2C), or the command refactor (2D) can proceed.
+
+**Constitution enforcement**:
+
+- §I Backward Compatibility: FR-016 enforced by regression baseline in T003 and
+  confirmed again in T023 and T031 (full suite passes unchanged).
+- §VI Platform Parity: FR-009 tasks T013 (PowerShell) and T014 (Bash) require
+  dual equivalent scripts; parity verified in T017.
+- §VIII Markdown Quality: T010 runs markdownlint after all 2A files are authored.
+
+**⚠️ CRITICAL**: No 2B, 2C, or 2D work can begin until this phase is complete.
+
+- [ ] T004 Author `templates/skills/SKILL-validation-contract.md` — upstream
+  Agent Skills frontmatter rules (name/description/length limits) + DevSpark
+  addendum (required `metadata.version`, required body sections, body-length
+  budget, prohibited keys, repair rules consistent with
+  `templates/spec-validation-contract.md`); MUST include the three-tier exit-code
+  table: `pass` exits 0 (one-line summary on stdout); `warn` exits 0 with
+  warning count on stderr and advisory details (body budget pressure does not
+  block CI); `fail` exits 1 with diagnostic `[RULE] [OFFENDING-VALUE] message`
+  on stderr (critic-002 — prevents CI silently accepting oversized skills)
+- [ ] T005 Author `templates/skills/ADAPTER-contract.md` — skill discovery rules,
+  input mapping (`$FEATURE_DESCRIPTION`, `$CONSTITUTION_PATH`,
+  `$PRIOR_SPEC_SUMMARY`), output mapping (draft → SPEC_FILE), responsibility
+  split (command vs. skill vs. adapter), backward-compatibility rules
+- [ ] T006 Complete `templates/skills/references/devspark-skills-guide.md` —
+  **SC-005 owner**: this file carries the step-by-step new-skill walkthrough;
+  ensure it includes: (a) validation surface section, (b) adding-a-skill workflow
+  with numbered steps referencing T004 contracts + write-spec as the worked
+  example, (c) review checklist section; content must be sufficient for a new
+  contributor to author and pass a second skill on their first PR attempt
+  (SC-005); consistent with T004/T005 contracts
+- [ ] T007 Author `templates/skills/README.md` — pointer-only landing page for
+  the `skills/` surface; dual-surface model summary (`command → adapter → skill`);
+  links to `ADAPTER-contract.md`, `SKILL-validation-contract.md`, and
+  `references/devspark-skills-guide.md` (where the SC-005 walkthrough lives);
+  does not duplicate walkthrough content
+- [ ] T008 Update `README.md` (repo root) — add positioning statement ("DevSpark
+  treats skills as portable capability packages within a governed lifecycle
+  orchestration system"), dual-surface model description, pointers to
+  `templates/skills/README.md` and the two contract files (FR-019)
+- [ ] T009 Update `CLAUDE.md` — add positioning statement and `command → invokes →
+  skill` internal architecture note; pointer to `templates/skills/` (FR-019)
+- [ ] T010 Run `npx markdownlint-cli2 "**/*.md"` — confirm zero errors after all
+  2A files are authored (§VIII gate)
+
+**Checkpoint 2A**: `ADAPTER-contract.md` and `SKILL-validation-contract.md` both
+exist and are lint-clean; `devspark-skills-guide.md` is complete; `README.md`
+and `CLAUDE.md` carry the FR-019 updates. Proceed to 2B.
+
+---
+
+## Phase 3: User Story 1 — Portable skill executes in a non-DevSpark client (P1)
+
+**Goal**: A skills-compatible client with no DevSpark installation can load
+`templates/skills/write-spec/` and produce a valid `spec.md` artifact.
+
+**Independent Test**: Copy only `templates/skills/write-spec/` into a fresh
+workspace without DevSpark CLI installed. Load into a skills-compatible client
+per its standard installation flow. Request a draft spec for a sample feature
+description. Verify the produced `spec.md` conforms to
+`templates/spec-validation-contract.md`.
+
+**Sub-phase**: 2B — Standalone `write-spec` Skill.
+
+**Completion gate**: `SKILL.md` exists; both context scripts run on this repo
+without error; markdownlint passes; FR-004 through FR-010 satisfied.
+
+### Implementation for User Story 1
+
+- [ ] T011 [US1] Author `templates/skills/write-spec/SKILL.md` — frontmatter:
+  `name: write-spec`, discovery-rich `description` (≤ 1024 chars, includes
+  keywords: draft specification, feature spec, requirements document, user
+  stories, acceptance criteria), `metadata.version: "0.1.0"`; no DevSpark-only
+  keys; body ≤ 500 lines; body instructs agent to: (a) run context-gathering
+  scripts and parse JSON output; (b) if script output is empty, non-JSON, or
+  the script exits non-zero, treat as fallback
+  `{"constitution_summary": null, "prior_specs": [], "skipped_context":
+  ["script-error"]}` and proceed without blocking (critic-005 — graceful
+  degradation when script fails, not just when git/constitution is unavailable);
+  (c) load constitution summary and prior-spec summary from parsed context;
+  (d) draft spec per shared validation contract; (e) limit
+  `[NEEDS CLARIFICATION]` to max 3; (f) record any skipped context in the
+  spec's Assumptions section; (g) set status `Draft` (FR-004–FR-007, FR-010)
+- [ ] T012 [P] [US1] Author at least one `templates/skills/write-spec/references/`
+  file — factor out spec template structure, clarification question format, and
+  success criteria guidelines from the skill body; reference with relative paths
+  from skill root (FR-007)
+- [ ] T013 [P] [US1] Author `templates/skills/write-spec/scripts/gather-context.ps1`
+  — PowerShell: detect git repo, load constitution (emit summary), list prior
+  specs under `.documentation/specs/`; always exit 0 and always emit valid JSON
+  (critic-005 — the skill cannot guard against a non-zero exit if the script
+  exits non-zero); output JSON schema:
+  `{"constitution_summary": string|null, "prior_specs": [...], "skipped_context":
+  [...]}` where `skipped_context` lists any context that could not be gathered
+  (e.g., `"no-git-repo"`, `"constitution-not-found"`) and remaining fields are
+  null/empty; degrade gracefully when git or constitution is unavailable;
+  never block skill execution (FR-008, FR-009, FR-010)
+- [ ] T014 [P] [US1] Author `templates/skills/write-spec/scripts/gather-context.sh`
+  — Bash equivalent of T013; functionally identical JSON output schema and
+  exit-0 contract (critic-005); handles missing git, missing constitution,
+  non-repo context; records skipped context in `skipped_context` array;
+  always exits 0 and always emits valid JSON (FR-009, FR-010)
+- [ ] T015 [US1] Manually validate `SKILL.md` against `SKILL-validation-contract.md`
+  (from T004): name matches directory, description within limits, `metadata.version`
+  quoted, no prohibited keys, body within budget, degradation documented in
+  Assumptions (SC-001, SC-007)
+- [ ] T016 [P] [US1] Run `npx markdownlint-cli2 "**/*.md"` — confirm zero errors
+  after all 2B Markdown files are authored (§VIII, FR-018)
+- [ ] T017 [P] [US1] Run both context-gathering scripts against the current
+  repository: `.\templates\skills\write-spec\scripts\gather-context.ps1` and
+  `bash templates/skills/write-spec/scripts/gather-context.sh`; verify JSON
+  output contains `constitution_summary` and `prior_specs` keys; verify
+  `skipped_context` array present (SC-007)
+
+**Checkpoint 2B / US1**: `write-spec/SKILL.md` is valid; both scripts produce
+correct JSON on this repo; markdownlint clean. Proceed to 2C tests.
+
+---
+
+## Phase 4: User Story 3 — Maintainer validates a skill before merging (P2)
+
+**Goal**: A contributor can run a single CLI command to validate a skill against
+the open spec, the DevSpark addendum, and the adapter contract. CI runs the same
+validation on every PR.
+
+**Independent Test**: Run `devspark skills validate` against a valid skill
+(exits 0 + summary) and against a deliberately broken skill fixture (exits 1 +
+named rule + offending value).
+
+**Note**: US3 is implemented before US2 because the test gate (US3) must exist
+before the command refactor (US2/2D). This ordering is required by the spec
+(2A → 2B → 2C → 2D).
+
+**Sub-phase**: 2C — Tests and CLI.
+
+### Tests for User Story 3
+
+- [ ] T018 [P] [US3] Author `tests/test_skill_contract.py` — discovers all
+  directories under `templates/skills/` that contain `SKILL.md`; for each:
+  parse YAML frontmatter using `yaml.safe_load()` (SafeLoader — avoids YAML 1.1
+  boolean surprises where bare `yes`/`no`/`on`/`off` become Python booleans,
+  critic-003); assert `name` matches parent directory; assert `name` matches
+  regex `^[a-z0-9]+(-[a-z0-9]+)*$` (no leading/trailing/consecutive hyphens);
+  assert `description` is non-empty and `len(description) <= 1024`; assert
+  `metadata.version` is of type `str` (not int/float — rejects unquoted `1.0`)
+  and matches regex `^\d+\.\d+\.\d+$` (full MAJOR.MINOR.PATCH — rejects `"1.0"`
+  missing patch, critic-003); assert no prohibited DevSpark-only keys
+  (`handoffs`, `scripts`, `classification`, `required_gates`,
+  `recommended_next_step`, `version`) present in frontmatter; assert body line
+  count ≤ 500 (fail) and emit warning when > 400 lines (warn tier); assert
+  SKILL.md body contains none of the DevSpark-specific strings `.devspark/`,
+  `{SCRIPT}`, `FEATURE_DIR`, `{AGENT_SCRIPT}`, `handoffs:` (portability
+  body-scan, critic-008 — catches DevSpark leakage before manual portability
+  check T032); include a deliberate-violation fixture set: uppercase name,
+  description > 1024 chars, unquoted float version, partial semver, prohibited
+  key, body with DevSpark-specific string — each fixture must fail with an
+  assertion message naming the violated rule (FR-011, SC-002)
+- [ ] T019 [P] [US3] Author `tests/test_adapter_contract.py` — asserts
+  `templates/commands/specify.md` contains a reference to `write-spec` skill;
+  asserts `specify.md` does not contain the inline spec-drafting procedure
+  post-2D refactor (add as an xfail/skip marker for now, to be enabled in T026
+  after T025 refactor completes); **note: FR-012(c) (integration-test pass
+  assertion) is a stub here — it is not fully enforced until T027 runs the full
+  integration suite against the refactored command; T019 alone does not satisfy
+  FR-012(c)**; add cross-file grep assertions that the three named adapter input
+  variables (`$FEATURE_DESCRIPTION`, `$CONSTITUTION_PATH`, `$PRIOR_SPEC_SUMMARY`)
+  appear in both `specify.md`'s delegation block and `ADAPTER-contract.md`
+  (critic-004 — makes the variable contract machine-verifiable) (FR-012, SC-003)
+
+### Implementation for User Story 3
+
+- [ ] T020 [US3] Author `src/devspark_cli/commands/skills.py` — implements
+  `skills_app = typer.Typer(name="skills")`; subcommand `list`: enumerate all
+  directories under `templates/skills/` that contain `SKILL.md`, print Rich
+  table (name, version, path, status); **no `--json` flag in this release**
+  (critic-007 decision: output format is not yet stable; document in a comment
+  that `--json` is deferred and the format should not be parsed by scripts
+  until stabilised in a future semver release); subcommand `validate [path]`:
+  validate all skills or one supplied path using `yaml.safe_load()` (SafeLoader,
+  not default Loader); implement three-tier exit codes: pass → exit 0 + summary
+  on stdout; warn → exit 0 + warning count on stderr; fail → exit 1 + diagnostic
+  `[RULE] [OFFENDING-VALUE] message` on stderr; parse frontmatter and run all
+  rules from `SKILL-validation-contract.md` (FR-013)
+- [ ] T021 [US3] Wire `skills_app` into `src/devspark_cli/_app.py` — add
+  `app.add_typer(skills_app, name="skills")` alongside existing `harness_app`
+  and `adapter_app` (FR-013)
+- [ ] T022 [US3] Run `pytest tests/test_skill_contract.py tests/test_adapter_contract.py`
+  — confirm T018/T019 pass; confirm `devspark skills validate` exits 0 against
+  current `write-spec` skill; confirm deliberate-violation fixture exits 1 with
+  named rule (SC-002)
+- [ ] T023 [P] [US3] Run full test suite `pytest tests/` — confirm no regressions
+  from CLI wiring (SC-006)
+
+**Checkpoint 2C / US3**: Both new test modules pass; `devspark skills list` and
+`devspark skills validate` are wired and functional; regression baseline held.
+Proceed to 2D.
+
+---
+
+## Phase 5: User Story 2 — DevSpark command invokes skill internally (P1)
+
+**Goal**: Running `/devspark.specify "..."` inside a DevSpark-enabled repository
+produces the same user-observable artifacts as before, but the spec-drafting
+reasoning is now delegated to the `write-spec` skill via the adapter contract.
+
+**Independent Test**: Run the existing `/devspark.specify` integration test suite
+(`tests/test_create_spec_workflow_integration.py` and related) against the
+refactored command. All tests must pass unchanged. Additionally,
+`tests/test_adapter_contract.py` must confirm delegation.
+
+**Sub-phase**: 2D — Thin-Wrapper Command Refactor.
+
+### Implementation for User Story 2
+
+- [ ] T024 [US2] Read `templates/commands/specify.md` in full before editing —
+  identify the inline spec-drafting procedure section (the block starting at step
+  4 "Follow this execution flow" through step 5 "Write the specification")
+- [ ] T025 [US2] Refactor `templates/commands/specify.md` — retain all DevSpark
+  lifecycle steps (route classification at step 0, branch creation at step 2,
+  multi-app scoping, artifact placement at step 5, checklist generation at
+  step 6, gate enforcement); replace the inline spec-drafting procedure with a
+  delegation block that: (a) resolves `templates/skills/write-spec/SKILL.md`
+  via the adapter contract, (b) passes `$FEATURE_DESCRIPTION`, `$CONSTITUTION_PATH`,
+  and `$PRIOR_SPEC_SUMMARY` as named inputs, (c) places the skill-produced draft
+  into `SPEC_FILE`; multi-app scope resolution remains a command responsibility
+  and is NOT passed into the skill body (FR-014, FR-015, SC-003)
+- [ ] T026 [US2] Enable the previously-skipped adapter contract assertion in
+  `tests/test_adapter_contract.py` (T019) that verifies `specify.md` references
+  `write-spec` and does not duplicate the drafting procedure inline (FR-012)
+- [ ] T027 [US2] Run `pytest tests/test_create_spec_workflow_integration.py` and
+  all related specify integration tests — confirm all pass unchanged after the
+  refactor (FR-015, SC-003)
+- [ ] T028 [US2] Run `pytest tests/test_adapter_contract.py` — confirm delegation
+  assertion now passes with the refactored command (FR-012)
+- [ ] T029 [P] [US2] Run `npx markdownlint-cli2 "**/*.md"` — confirm zero errors
+  on modified `specify.md` (§VIII, FR-018)
+
+**Checkpoint 2D / US2**: All existing integration tests pass unchanged; adapter
+contract test confirms delegation; markdownlint clean.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Final validation sweep across all surfaces introduced by this feature.
+
+- [ ] T030 [P] Run full markdownlint sweep: `npx markdownlint-cli2 "**/*.md"` —
+  confirm zero errors across all new and modified Markdown files (§VIII, FR-018,
+  SC-004)
+- [ ] T031 [P] Run full test suite: `pytest tests/` — confirm all tests pass;
+  zero regressions in any existing test (SC-006)
+- [ ] T032 Perform manual portability check: copy only
+  `templates/skills/write-spec/` to a temporary directory; open with a
+  skills-compatible client; request a draft spec for a sample feature description;
+  verify the resulting `spec.md` has valid frontmatter, four mandatory full-spec
+  sections, `Draft` status, and ≤ 3 `[NEEDS CLARIFICATION]` markers (SC-001,
+  US1 acceptance scenario 1)
+- [ ] T033 [P] Verify `devspark skills list` output — confirm it enumerates
+  `write-spec` with correct name, version `0.1.0`, path, and `pass` status
+  (SC-002, FR-013)
+- [ ] T034 [P] Verify `devspark skills validate` exit code — zero for `write-spec`;
+  non-zero with named rule for deliberate-violation fixture (SC-002, US3
+  acceptance scenario 2)
+- [ ] T035 Review `CLAUDE.md` and `README.md` FR-019 updates — confirm positioning
+  statement, dual-surface model description, and all four pointers are present
+  and links resolve (FR-019)
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Phase 1 (Setup)**: No dependencies — start immediately.
+- **Phase 2 (2A Foundation)**: Depends on Phase 1 — blocks all subsequent phases.
+- **Phase 3 (2B / US1)**: Depends on Phase 2 completion — contract files must be
+  stable before skill is authored.
+- **Phase 4 (2C / US3)**: Depends on Phase 3 completion — skill must exist before
+  tests assert on it.
+- **Phase 5 (2D / US2)**: Depends on Phase 4 completion — test gate must exist
+  before command is refactored.
+- **Phase 6 (Polish)**: Depends on Phase 5 completion.
+
+### User Story Dependencies
+
+- **US1 (P1 — Portable skill)**: Depends on 2A foundation only. No dependency on
+  US2 or US3.
+- **US3 (P2 — Validation)**: Depends on US1 (skill must exist to be validated).
+  Implemented before US2 to establish the test gate.
+- **US2 (P1 — Command integration)**: Depends on US3 (test gate must exist before
+  refactor). Final delivery sub-phase.
+
+### Within Each Phase
+
+- Markdown files in Phase 2: T004 and T005 can be authored in parallel (different
+  files); T006 depends on T004/T005 being stable; T007 depends on T006; T008/T009
+  can be parallel with T007; T010 runs after all Phase 2 files are authored.
+- Scripts in Phase 3: T013 and T014 can be authored in parallel (different files,
+  same output schema); both depend on T011 for output schema reference.
+
+### Parallel Opportunities
+
+Within Phase 2 (once started):
+
+- T004 and T005 are parallelizable (different files)
+- T008 and T009 are parallelizable (different files)
+- T010 is a gate — runs after T004–T009
+
+Within Phase 3 (once T011 is complete):
+
+- T012, T013, T014 are parallelizable (different files)
+- T016 and T017 run after T011–T014
+
+Within Phase 4 (once T011 and T004/T005 are complete):
+
+- T018 and T019 can be authored in parallel (different files)
+- T020 and T021 are sequential (T021 imports from T020)
+- T022 and T023 run after T020/T021
+
+---
+
+## Parallel Example: Phase 3 (User Story 1)
+
+```text
+# After T011 (SKILL.md) is complete, launch in parallel:
+Task T012: Author write-spec/references/ files
+Task T013: Author gather-context.ps1
+Task T014: Author gather-context.sh
+
+# After all three complete:
+Task T015: Manual validation against SKILL-validation-contract.md
+Task T016: markdownlint sweep
+Task T017: Run both scripts against current repo
+```
+
+---
+
+## Gate Acknowledgements
+
+- **Gate**: checklists/requirements.md
+- **Concern**: One item marked incomplete — "No [NEEDS CLARIFICATION] markers
+  remain" — was flagged based on an earlier pre-clarifications-session state of
+  the spec. After review, no actual `[NEEDS CLARIFICATION]` markers remain in
+  `spec.md`; the two occurrences found by grep are content references (acceptance
+  scenario wording and FR-006 rule text), not open markers. FR-020 distribution
+  surface was resolved via the Clarifications session 2026-05-19 (in-repo
+  distribution only). The checklist item is stale.
+- **Decision**: Proceed — the underlying concern is resolved; the checklist item
+  will be updated as part of T035.
+- **Recorded By**: /devspark.tasks
+- **Date**: 2026-05-19
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 — Portable Skill)
+
+1. Complete Phase 1: Setup (T001–T003)
+2. Complete Phase 2: 2A Foundation (T004–T010) — **blocks all stories**
+3. Complete Phase 3: US1 / 2B Skill (T011–T017)
+4. **STOP and VALIDATE**: Manual portability check (T032 preview)
+5. Portable skill is usable by any skills-compatible client
+
+### Incremental Delivery
+
+1. Phase 1 + Phase 2 → Contract foundation ready
+2. Phase 3 (US1) → Portable `write-spec` skill ships
+3. Phase 4 (US3) → Validation CLI + test gate ships
+4. Phase 5 (US2) → Command refactor ships; full dual-surface model live
+5. Phase 6 (Polish) → Final sweep and portability confirmation
+
+### Single-Developer Sequence
+
+Because the sub-phase ordering is non-negotiable (2A → 2B → 2C → 2D), this
+feature is designed as a sequential delivery by one developer, with parallel
+opportunities within each phase where marked [P].
+
+---
+
+## Notes
+
+- [P] tasks = different files, no shared state dependencies — safe to run in
+  parallel within the same phase
+- [US*] label maps each task to a specific user story for traceability
+- Sub-phase ordering (2A → 2B → 2C → 2D) is non-negotiable per the spec
+- §VIII (Markdown Quality): run markdownlint after every authoring phase, not
+  only at the end — T010, T016, T029, T030
+- §VI (Platform Parity): T013 and T014 must be functionally equivalent; verify
+  JSON output schema matches between PS and Bash scripts
+- Tests required by spec: T018, T019, T022, T023, T027, T028 are not optional
+- Commit after each phase checkpoint to keep diffs auditable (§VII)
+- Avoid: editing `SKILL.md` and `specify.md` in the same commit (reviewer
+  clarity); cross-phase work before phase gate is passed

--- a/.documentation/specs/003-add-first-skill/tasks.md
+++ b/.documentation/specs/003-add-first-skill/tasks.md
@@ -60,15 +60,17 @@ Single project layout. Skills surface under `templates/skills/`. CLI under
 **Purpose**: Confirm directory skeleton exists and markdownlint baseline is green
 before authoring any new files.
 
-- [ ] T001 Verify `templates/skills/` directory exists with `write-spec/` and
+- [x] T001 Verify `templates/skills/` directory exists with `write-spec/` and
   `references/` subdirectories; create any missing directories; confirm
   `PyYAML>=6.0` is present as a direct dependency in `pyproject.toml`
   (critic-006 — already declared; verification step ensures it stays explicit
   if lockfile is regenerated)
-- [ ] T002 [P] Run `npx markdownlint-cli2 "**/*.md"` from repo root and confirm
+- [x] T002 [P] Run `npx markdownlint-cli2 "**/*.md"` from repo root and confirm
   zero errors as the baseline before new files are added
-- [ ] T003 [P] Confirm existing test suite passes: `pytest tests/` (establishes
+- [x] T003 [P] Confirm existing test suite passes: `pytest tests/` (establishes
   regression baseline before any code changes)
+
+**Checkpoint**: Phase complete — 2026-05-19
 
 ---
 
@@ -87,7 +89,7 @@ skill body (2B), the tests (2C), or the command refactor (2D) can proceed.
 
 **⚠️ CRITICAL**: No 2B, 2C, or 2D work can begin until this phase is complete.
 
-- [ ] T004 Author `templates/skills/SKILL-validation-contract.md` — upstream
+- [x] T004 Author `templates/skills/SKILL-validation-contract.md` — upstream
   Agent Skills frontmatter rules (name/description/length limits) + DevSpark
   addendum (required `metadata.version`, required body sections, body-length
   budget, prohibited keys, repair rules consistent with
@@ -96,34 +98,36 @@ skill body (2B), the tests (2C), or the command refactor (2D) can proceed.
   warning count on stderr and advisory details (body budget pressure does not
   block CI); `fail` exits 1 with diagnostic `[RULE] [OFFENDING-VALUE] message`
   on stderr (critic-002 — prevents CI silently accepting oversized skills)
-- [ ] T005 Author `templates/skills/ADAPTER-contract.md` — skill discovery rules,
+- [x] T005 Author `templates/skills/ADAPTER-contract.md` — skill discovery rules,
   input mapping (`$FEATURE_DESCRIPTION`, `$CONSTITUTION_PATH`,
   `$PRIOR_SPEC_SUMMARY`), output mapping (draft → SPEC_FILE), responsibility
   split (command vs. skill vs. adapter), backward-compatibility rules
-- [ ] T006 Complete `templates/skills/references/devspark-skills-guide.md` —
+- [x] T006 Complete `templates/skills/references/devspark-skills-guide.md` —
   **SC-005 owner**: this file carries the step-by-step new-skill walkthrough;
   ensure it includes: (a) validation surface section, (b) adding-a-skill workflow
   with numbered steps referencing T004 contracts + write-spec as the worked
   example, (c) review checklist section; content must be sufficient for a new
   contributor to author and pass a second skill on their first PR attempt
   (SC-005); consistent with T004/T005 contracts
-- [ ] T007 Author `templates/skills/README.md` — pointer-only landing page for
+- [x] T007 Author `templates/skills/README.md` — pointer-only landing page for
   the `skills/` surface; dual-surface model summary (`command → adapter → skill`);
   links to `ADAPTER-contract.md`, `SKILL-validation-contract.md`, and
   `references/devspark-skills-guide.md` (where the SC-005 walkthrough lives);
   does not duplicate walkthrough content
-- [ ] T008 Update `README.md` (repo root) — add positioning statement ("DevSpark
+- [x] T008 Update `README.md` (repo root) — add positioning statement ("DevSpark
   treats skills as portable capability packages within a governed lifecycle
   orchestration system"), dual-surface model description, pointers to
   `templates/skills/README.md` and the two contract files (FR-019)
-- [ ] T009 Update `CLAUDE.md` — add positioning statement and `command → invokes →
+- [x] T009 Update `CLAUDE.md` — add positioning statement and `command → invokes →
   skill` internal architecture note; pointer to `templates/skills/` (FR-019)
-- [ ] T010 Run `npx markdownlint-cli2 "**/*.md"` — confirm zero errors after all
+- [x] T010 Run `npx markdownlint-cli2 "**/*.md"` — confirm zero errors after all
   2A files are authored (§VIII gate)
 
 **Checkpoint 2A**: `ADAPTER-contract.md` and `SKILL-validation-contract.md` both
 exist and are lint-clean; `devspark-skills-guide.md` is complete; `README.md`
 and `CLAUDE.md` carry the FR-019 updates. Proceed to 2B.
+
+**Checkpoint**: Phase complete — 2026-05-19
 
 ---
 
@@ -145,7 +149,7 @@ without error; markdownlint passes; FR-004 through FR-010 satisfied.
 
 ### Implementation for User Story 1
 
-- [ ] T011 [US1] Author `templates/skills/write-spec/SKILL.md` — frontmatter:
+- [x] T011 [US1] Author `templates/skills/write-spec/SKILL.md` — frontmatter:
   `name: write-spec`, discovery-rich `description` (≤ 1024 chars, includes
   keywords: draft specification, feature spec, requirements document, user
   stories, acceptance criteria), `metadata.version: "0.1.0"`; no DevSpark-only
@@ -159,11 +163,11 @@ without error; markdownlint passes; FR-004 through FR-010 satisfied.
   (d) draft spec per shared validation contract; (e) limit
   `[NEEDS CLARIFICATION]` to max 3; (f) record any skipped context in the
   spec's Assumptions section; (g) set status `Draft` (FR-004–FR-007, FR-010)
-- [ ] T012 [P] [US1] Author at least one `templates/skills/write-spec/references/`
+- [x] T012 [P] [US1] Author at least one `templates/skills/write-spec/references/`
   file — factor out spec template structure, clarification question format, and
   success criteria guidelines from the skill body; reference with relative paths
   from skill root (FR-007)
-- [ ] T013 [P] [US1] Author `templates/skills/write-spec/scripts/gather-context.ps1`
+- [x] T013 [P] [US1] Author `templates/skills/write-spec/scripts/gather-context.ps1`
   — PowerShell: detect git repo, load constitution (emit summary), list prior
   specs under `.documentation/specs/`; always exit 0 and always emit valid JSON
   (critic-005 — the skill cannot guard against a non-zero exit if the script
@@ -173,18 +177,18 @@ without error; markdownlint passes; FR-004 through FR-010 satisfied.
   (e.g., `"no-git-repo"`, `"constitution-not-found"`) and remaining fields are
   null/empty; degrade gracefully when git or constitution is unavailable;
   never block skill execution (FR-008, FR-009, FR-010)
-- [ ] T014 [P] [US1] Author `templates/skills/write-spec/scripts/gather-context.sh`
+- [x] T014 [P] [US1] Author `templates/skills/write-spec/scripts/gather-context.sh`
   — Bash equivalent of T013; functionally identical JSON output schema and
   exit-0 contract (critic-005); handles missing git, missing constitution,
   non-repo context; records skipped context in `skipped_context` array;
   always exits 0 and always emits valid JSON (FR-009, FR-010)
-- [ ] T015 [US1] Manually validate `SKILL.md` against `SKILL-validation-contract.md`
+- [x] T015 [US1] Manually validate `SKILL.md` against `SKILL-validation-contract.md`
   (from T004): name matches directory, description within limits, `metadata.version`
   quoted, no prohibited keys, body within budget, degradation documented in
   Assumptions (SC-001, SC-007)
-- [ ] T016 [P] [US1] Run `npx markdownlint-cli2 "**/*.md"` — confirm zero errors
+- [x] T016 [P] [US1] Run `npx markdownlint-cli2 "**/*.md"` — confirm zero errors
   after all 2B Markdown files are authored (§VIII, FR-018)
-- [ ] T017 [P] [US1] Run both context-gathering scripts against the current
+- [x] T017 [P] [US1] Run both context-gathering scripts against the current
   repository: `.\templates\skills\write-spec\scripts\gather-context.ps1` and
   `bash templates/skills/write-spec/scripts/gather-context.sh`; verify JSON
   output contains `constitution_summary` and `prior_specs` keys; verify
@@ -192,6 +196,8 @@ without error; markdownlint passes; FR-004 through FR-010 satisfied.
 
 **Checkpoint 2B / US1**: `write-spec/SKILL.md` is valid; both scripts produce
 correct JSON on this repo; markdownlint clean. Proceed to 2C tests.
+
+**Checkpoint**: Phase complete — 2026-05-19
 
 ---
 
@@ -213,7 +219,7 @@ before the command refactor (US2/2D). This ordering is required by the spec
 
 ### Tests for User Story 3
 
-- [ ] T018 [P] [US3] Author `tests/test_skill_contract.py` — discovers all
+- [x] T018 [P] [US3] Author `tests/test_skill_contract.py` — discovers all
   directories under `templates/skills/` that contain `SKILL.md`; for each:
   parse YAML frontmatter using `yaml.safe_load()` (SafeLoader — avoids YAML 1.1
   boolean surprises where bare `yes`/`no`/`on`/`off` become Python booleans,
@@ -233,7 +239,7 @@ before the command refactor (US2/2D). This ordering is required by the spec
   description > 1024 chars, unquoted float version, partial semver, prohibited
   key, body with DevSpark-specific string — each fixture must fail with an
   assertion message naming the violated rule (FR-011, SC-002)
-- [ ] T019 [P] [US3] Author `tests/test_adapter_contract.py` — asserts
+- [x] T019 [P] [US3] Author `tests/test_adapter_contract.py` — asserts
   `templates/commands/specify.md` contains a reference to `write-spec` skill;
   asserts `specify.md` does not contain the inline spec-drafting procedure
   post-2D refactor (add as an xfail/skip marker for now, to be enabled in T026
@@ -247,7 +253,7 @@ before the command refactor (US2/2D). This ordering is required by the spec
 
 ### Implementation for User Story 3
 
-- [ ] T020 [US3] Author `src/devspark_cli/commands/skills.py` — implements
+- [x] T020 [US3] Author `src/devspark_cli/commands/skills.py` — implements
   `skills_app = typer.Typer(name="skills")`; subcommand `list`: enumerate all
   directories under `templates/skills/` that contain `SKILL.md`, print Rich
   table (name, version, path, status); **no `--json` flag in this release**
@@ -259,19 +265,21 @@ before the command refactor (US2/2D). This ordering is required by the spec
   on stdout; warn → exit 0 + warning count on stderr; fail → exit 1 + diagnostic
   `[RULE] [OFFENDING-VALUE] message` on stderr; parse frontmatter and run all
   rules from `SKILL-validation-contract.md` (FR-013)
-- [ ] T021 [US3] Wire `skills_app` into `src/devspark_cli/_app.py` — add
+- [x] T021 [US3] Wire `skills_app` into `src/devspark_cli/_app.py` — add
   `app.add_typer(skills_app, name="skills")` alongside existing `harness_app`
   and `adapter_app` (FR-013)
-- [ ] T022 [US3] Run `pytest tests/test_skill_contract.py tests/test_adapter_contract.py`
+- [x] T022 [US3] Run `pytest tests/test_skill_contract.py tests/test_adapter_contract.py`
   — confirm T018/T019 pass; confirm `devspark skills validate` exits 0 against
   current `write-spec` skill; confirm deliberate-violation fixture exits 1 with
   named rule (SC-002)
-- [ ] T023 [P] [US3] Run full test suite `pytest tests/` — confirm no regressions
+- [x] T023 [P] [US3] Run full test suite `pytest tests/` — confirm no regressions
   from CLI wiring (SC-006)
 
 **Checkpoint 2C / US3**: Both new test modules pass; `devspark skills list` and
 `devspark skills validate` are wired and functional; regression baseline held.
 Proceed to 2D.
+
+**Checkpoint**: Phase complete — 2026-05-19
 
 ---
 
@@ -290,10 +298,10 @@ refactored command. All tests must pass unchanged. Additionally,
 
 ### Implementation for User Story 2
 
-- [ ] T024 [US2] Read `templates/commands/specify.md` in full before editing —
+- [x] T024 [US2] Read `templates/commands/specify.md` in full before editing —
   identify the inline spec-drafting procedure section (the block starting at step
   4 "Follow this execution flow" through step 5 "Write the specification")
-- [ ] T025 [US2] Refactor `templates/commands/specify.md` — retain all DevSpark
+- [x] T025 [US2] Refactor `templates/commands/specify.md` — retain all DevSpark
   lifecycle steps (route classification at step 0, branch creation at step 2,
   multi-app scoping, artifact placement at step 5, checklist generation at
   step 6, gate enforcement); replace the inline spec-drafting procedure with a
@@ -302,19 +310,23 @@ refactored command. All tests must pass unchanged. Additionally,
   and `$PRIOR_SPEC_SUMMARY` as named inputs, (c) places the skill-produced draft
   into `SPEC_FILE`; multi-app scope resolution remains a command responsibility
   and is NOT passed into the skill body (FR-014, FR-015, SC-003)
-- [ ] T026 [US2] Enable the previously-skipped adapter contract assertion in
+- [x] T026 [US2] Enable the previously-skipped adapter contract assertion in
   `tests/test_adapter_contract.py` (T019) that verifies `specify.md` references
   `write-spec` and does not duplicate the drafting procedure inline (FR-012)
-- [ ] T027 [US2] Run `pytest tests/test_create_spec_workflow_integration.py` and
+- [x] T027 [US2] Run `pytest tests/test_create_spec_workflow_integration.py` and
   all related specify integration tests — confirm all pass unchanged after the
   refactor (FR-015, SC-003)
-- [ ] T028 [US2] Run `pytest tests/test_adapter_contract.py` — confirm delegation
+- [x] T028 [US2] Run `pytest tests/test_adapter_contract.py` — confirm delegation
   assertion now passes with the refactored command (FR-012)
-- [ ] T029 [P] [US2] Run `npx markdownlint-cli2 "**/*.md"` — confirm zero errors
+- [x] T029 [P] [US2] Run `npx markdownlint-cli2 "**/*.md"` — confirm zero errors
   on modified `specify.md` (§VIII, FR-018)
 
 **Checkpoint 2D / US2**: All existing integration tests pass unchanged; adapter
 contract test confirms delegation; markdownlint clean.
+
+**Checkpoint**: Phase complete — 2026-05-19
+
+### User Story 2 ✅ Complete
 
 ---
 
@@ -322,26 +334,28 @@ contract test confirms delegation; markdownlint clean.
 
 **Purpose**: Final validation sweep across all surfaces introduced by this feature.
 
-- [ ] T030 [P] Run full markdownlint sweep: `npx markdownlint-cli2 "**/*.md"` —
+- [x] T030 [P] Run full markdownlint sweep: `npx markdownlint-cli2 "**/*.md"` —
   confirm zero errors across all new and modified Markdown files (§VIII, FR-018,
   SC-004)
-- [ ] T031 [P] Run full test suite: `pytest tests/` — confirm all tests pass;
+- [x] T031 [P] Run full test suite: `pytest tests/` — confirm all tests pass;
   zero regressions in any existing test (SC-006)
-- [ ] T032 Perform manual portability check: copy only
+- [x] T032 Perform manual portability check: copy only
   `templates/skills/write-spec/` to a temporary directory; open with a
   skills-compatible client; request a draft spec for a sample feature description;
   verify the resulting `spec.md` has valid frontmatter, four mandatory full-spec
   sections, `Draft` status, and ≤ 3 `[NEEDS CLARIFICATION]` markers (SC-001,
   US1 acceptance scenario 1)
-- [ ] T033 [P] Verify `devspark skills list` output — confirm it enumerates
+- [x] T033 [P] Verify `devspark skills list` output — confirm it enumerates
   `write-spec` with correct name, version `0.1.0`, path, and `pass` status
   (SC-002, FR-013)
-- [ ] T034 [P] Verify `devspark skills validate` exit code — zero for `write-spec`;
+- [x] T034 [P] Verify `devspark skills validate` exit code — zero for `write-spec`;
   non-zero with named rule for deliberate-violation fixture (SC-002, US3
   acceptance scenario 2)
-- [ ] T035 Review `CLAUDE.md` and `README.md` FR-019 updates — confirm positioning
+- [x] T035 Review `CLAUDE.md` and `README.md` FR-019 updates — confirm positioning
   statement, dual-surface model description, and all four pointers are present
   and links resolve (FR-019)
+
+**Checkpoint**: Phase complete — 2026-05-19
 
 ---
 

--- a/.documentation/specs/pr-review/pr-41.md
+++ b/.documentation/specs/pr-review/pr-41.md
@@ -1,0 +1,282 @@
+# Pull Request Review: feat(skills): add first Agent Skill — write-spec with adapter contract, validation CLI, and specify refactor
+
+## Review Metadata
+
+- **PR Number**: #41
+- **Source Branch**: 003-add-first-skill
+- **Target Branch**: main
+- **Review Date**: 2026-05-20 04:00:00 UTC
+- **Last Updated**: 2026-05-20 04:00:00 UTC
+- **Reviewed Commit**: 75bcfe1a0aaf429455c975736fef0eb3c5502d56
+- **Reviewer**: devspark.pr-review
+- **Constitution Version**: 1.3.0 (amended 2026-04-30)
+
+## Revision Log
+
+| Rev | Commit | Date | Critical | High | Medium | Low | CON | Test Command | Result |
+|-----|--------|------|----------|------|--------|-----|-----|--------------|--------|
+| 1 | 75bcfe1 | 2026-05-20 | 0 | 0 | 2 | 1 | 1 | `pytest tests/test_skill_contract.py tests/test_adapter_contract.py` | pass (28/28) |
+
+## PR Summary
+
+- **Author**: @markhazleton
+- **Created**: 2026-05-20
+- **Status**: OPEN
+- **Files Changed**: 21
+- **Commits**: 8
+- **Lines**: +4152 −26
+
+## Stats
+
+| Metric | Value |
+|--------|-------|
+| Files changed | 21 |
+| Lines added | +4152 |
+| Lines removed | −26 |
+| Net lines | +4126 |
+| Commit snapshot | `75bcfe1` |
+
+## Executive Summary
+
+- ✅ **Constitution Compliance**: PASS (8/8 principles checked)
+- 📋 **Spec Lifecycle**: Complete
+- 📝 **Task Completion**: 35/35 tasks complete
+- 🔒 **Security**: 0 issues found
+- 📊 **Code Quality**: 2 medium recommendations
+- 🧪 **Testing**: PASS (28 new tests pass; 159 total suite pass)
+- 📝 **Documentation**: PASS
+- 🏛️ **Constitution Improvements**: 1 CON finding
+
+**Overall Assessment**: A well-executed feature that introduces the Agent Skills surface cleanly and without regressions. The dual-surface architecture (`command → adapter → skill`) is clearly documented and machine-enforced via tests. Two medium findings (path resolution brittleness in production installs, and missing CI wiring for the new test modules) are worth addressing before or shortly after merge.
+
+**Approval Recommendation**: ⚠️ REQUEST CHANGES
+*Two medium findings (M-01, M-02) are worth resolving before merge. No critical or high issues found. If the author accepts these as post-merge follow-ups with filed issues, APPROVE is also defensible.*
+
+---
+
+## Action Items
+
+### Immediate Actions (Blocking — must resolve before merge)
+
+None found.
+
+### Recommended Improvements
+
+- [ ] **M-01** `src/devspark_cli/commands/skills.py:43-49` — `_find_skills_root()` uses `__file__`-relative path resolution that assumes a fixed directory depth (`commands/skills.py` → 4 parents = repo root). This breaks when the package is installed as a wheel (editable or non-editable) because the installed path is inside site-packages, not adjacent to `templates/`. The function silently returns a non-existent path and `skills list` reports "No skills found" with exit 0.
+- [ ] **M-02** `tests/test_skill_contract.py`, `tests/test_adapter_contract.py` — CI workflow (`.github/workflows/`) was not updated to require these new test files in the required-check set. The tests run locally but are not guaranteed to gate PRs in CI unless CI already runs the full `pytest tests/` suite (which the workflow appears to do, but this is worth confirming).
+- [ ] **L-01** `src/devspark_cli/commands/skills.py:9` — `import sys` is present but `sys` is never referenced in the final file (it was likely left from an earlier draft). Remove the unused import.
+
+### Constitution Improvements (Non-blocking — feed into `/devspark.evolve-constitution`)
+
+- [ ] **CON-01** — §V Simplicity does not currently address the path resolution pattern for CLI commands that discover framework assets. The `_find_skills_root()` pattern is a recurring problem (previously appeared in other commands). The constitution could benefit from a guiding principle or recommendation for how CLI commands locate `templates/` when installed as a package (e.g., using `importlib.resources` or an environment variable override).
+
+---
+
+## What's Good
+
+- **Architecture**: The four-layer boundary (`command → adapter → skill → context scripts → artifact`) is explicit, well-documented in `ADAPTER-contract.md`, and machine-verified by `test_adapter_contract.py`. The responsibility table is authoritative and unambiguous.
+- **Test discipline**: Deliberate-violation fixture set in `test_skill_contract.py` is a strong addition — it verifies that each rule *fails* with a named rule message, not just that the valid case passes. This is the right level of test coverage for a validation contract.
+- **Graceful degradation**: Both context-gathering scripts (`gather-context.ps1`, `gather-context.sh`) always exit 0 and always emit valid JSON — the `skipped_context` pattern handles partial context cleanly without blocking the skill.
+- **Portability discipline**: SKILL.md body-scan in tests (T018/critic-008) mechanically prevents DevSpark-specific strings from leaking into portable skill bodies. This is a maintainability win that pays forward.
+- **Commit hygiene**: 5 clean phase-grouped commits follow the sub-phase ordering (2A→2B→2C→2D→sync), making the diff auditable per §VII.
+
+---
+
+## Findings Detail
+
+### Critical Issues (Blocking)
+
+None found.
+
+### High Priority Issues
+
+None found.
+
+### Medium Priority Suggestions
+
+| ID | Status | Principle | File:Line | Issue | Recommendation |
+|----|--------|-----------|-----------|-------|----------------|
+| M-01 | 🔴 Open | §V Simplicity | `src/devspark_cli/commands/skills.py:43` | `_find_skills_root()` hardcodes a 4-level `__file__` parent chain to reach the repo root. When installed as a wheel, `__file__` resolves inside site-packages and the computed path does not exist. `skills list` silently returns "No skills found" with exit 0 — no error, no diagnostic. | Add an `os.environ.get("DEVSPARK_SKILLS_ROOT")` override, or locate `templates/skills/` relative to the package data declaration in `pyproject.toml` using `importlib.resources`. At minimum, add a fallback warning when the computed path does not exist. |
+| M-02 | 🔴 Open | §I Backward Compatibility | `.github/workflows/` (not changed) | Two new test modules (`test_skill_contract.py`, `test_adapter_contract.py`) are added but the CI workflow was not updated to explicitly include them in required checks. If CI runs `pytest tests/` broadly, they are covered — but this is implicit, not explicit. A future refactor of the CI matrix could silently drop them. | Confirm that the CI workflow runs `pytest tests/` (not a narrowed glob) and add a brief comment in the workflow file confirming skill tests are included. If CI uses a test matrix or file-pattern include list, add the new test files explicitly. |
+
+### Low Priority Improvements
+
+| ID | Status | Principle | File:Line | Issue | Recommendation |
+|----|--------|-----------|-----------|-------|----------------|
+| L-01 | 🔴 Open | §V Simplicity | `src/devspark_cli/commands/skills.py:9` | `import sys` on line 9 is unused — `sys` is not referenced anywhere in the final file. Likely left from an earlier draft iteration. | Remove `import sys`. |
+
+### Constitution Improvements
+
+| ID | Status | Section | Observation | Suggested Amendment |
+|----|--------|---------|-------------|---------------------|
+| CON-01 | 🔴 Open | §V Simplicity | The `_find_skills_root()` pattern of discovering framework assets via `__file__`-relative paths is a recurring problem in DevSpark CLI commands and is not addressed by any current principle. The constitution's §V guidance ("prefer conventions over configuration") does not resolve the install-time vs. source-checkout ambiguity. | Add a convention note to §V or a new §IX: "CLI commands that locate framework assets (templates/, skills/) MUST use an environment variable override (e.g., `DEVSPARK_ASSETS_ROOT`) or `importlib.resources` rather than `__file__`-relative paths, to ensure correct behavior after wheel installation." |
+
+---
+
+## Constitution Alignment Details
+
+| Principle | Status | Evidence | Notes |
+|-----------|--------|----------|-------|
+| §I Backward Compatibility | ✅ Pass | 27 commands unchanged; specify.md test suite passes (2/2 integration tests) | Only `specify.md` refactored; user-observable UX unchanged |
+| §II Explicit Over Implied | ✅ Pass | ADAPTER-contract.md explicitly documents responsibility split; no silent scope inference | Input mapping table is authoritative and machine-tested |
+| §III Ownership Boundary | ✅ Pass | No writes to `.documentation/` by framework code; skill ships under `templates/skills/` | FR-017 enforced architecturally |
+| §IV Governance Authority | ✅ Pass | Constitution authority extends to new skill surface; validation rules derived from constitution | SKILL-validation-contract.md explicitly inherits constitution constraints |
+| §V Simplicity | ⚠️ Partial | Single skill, minimal adapter, no config layer — justified by interoperability goal | M-01: `_find_skills_root()` path resolution brittleness is a simplicity concern under production installs |
+| §VI Platform Parity | ✅ Pass | `gather-context.ps1` and `gather-context.sh` both present; identical JSON schema and exit-0 contract verified | T017 run confirmed both scripts produce correct output |
+| §VII PR Review Artifact Commit Discipline | ✅ Pass | This review file is being committed separately from code changes | No co-mingling detected |
+| §VIII Markdown Quality | ✅ Pass | Zero markdownlint errors on all 7 new/modified markdown files | Baseline and post-implementation lint runs both clean |
+
+---
+
+## Security Checklist
+
+- [x] No hardcoded secrets or credentials — scripts emit JSON with no auth tokens; no credentials in any file
+- [x] Input validation present where needed — `validate_skills()` validates all frontmatter fields before processing
+- [x] Authentication/authorization checks appropriate — N/A (no auth surface introduced)
+- [x] No SQL injection vulnerabilities — N/A (no database access)
+- [x] No XSS vulnerabilities — N/A (no web rendering)
+- [x] Dependencies reviewed for vulnerabilities — PyYAML ≥6.0 confirmed direct dependency; `yaml.safe_load()` used throughout (no arbitrary code execution risk from YAML parsing)
+
+---
+
+## Testing Coverage
+
+**Status**: ADEQUATE
+
+- 19 contract tests (`TestSkillContract`) parametrized over all discovered skills; auto-extends as new skills are added
+- 6 deliberate-violation fixtures (`TestSkillContractViolationFixtures`) verify each rule fails with a named rule message
+- 9 adapter contract tests (`TestAdapterContractFiles`, `TestAdapterVariableContract`, `TestSpecifyReferencesSkill`) verify machine-enforced delegation contract
+- Integration tests for `specify.md` (2/2 pass unchanged after 2D refactor)
+- Full suite: 159 passed, 1 skipped, 0 failures
+
+## Test Inventory
+
+| File | Main | Branch | Delta | Justification |
+|------|------|--------|-------|---------------|
+| `tests/test_skill_contract.py` | 0 | 19 | +19 | New — full contract coverage for write-spec |
+| `tests/test_adapter_contract.py` | 0 | 9 | +9 | New — delegation contract verification |
+| **Total** | 0 | 28 | +28 | |
+
+No tests removed.
+
+---
+
+## Documentation Status
+
+**Status**: ADEQUATE
+
+- `README.md` updated with positioning statement and dual-surface model (FR-019)
+- `CLAUDE.md` updated with `command → invokes → skill` architecture note (FR-019)
+- `templates/skills/README.md` — landing page with dual-surface model summary
+- `templates/skills/ADAPTER-contract.md` — fully documented responsibility split, input/output mapping
+- `templates/skills/SKILL-validation-contract.md` — three-tier exit-code contract, prohibited keys, repair rules
+- `templates/skills/references/devspark-skills-guide.md` — step-by-step contributor walkthrough (SC-005)
+- `templates/skills/write-spec/references/spec-template.md` — spec structural reference
+
+---
+
+## Changed Files Summary
+
+| File | Tier | Changes | Type | Findings |
+|------|------|---------|------|---------|
+| `src/devspark_cli/_app.py` | P1 | +3 −0 | Modified | None |
+| `src/devspark_cli/commands/skills.py` | P1 | +278 −0 | Added | M-01, L-01 |
+| `templates/commands/specify.md` | P1 | +28 −26 | Modified | None |
+| `tests/test_skill_contract.py` | P2 | +278 −0 | Added | None |
+| `tests/test_adapter_contract.py` | P2 | +100 −0 | Added | M-02 |
+| `templates/skills/ADAPTER-contract.md` | P3 | +142 −0 | Added | None |
+| `templates/skills/SKILL-validation-contract.md` | P3 | +146 −0 | Added | None |
+| `templates/skills/README.md` | P3 | +64 −0 | Added | None |
+| `templates/skills/references/devspark-skills-guide.md` | P3 | +313 −0 | Added (pre-existing stub completed) | None |
+| `templates/skills/write-spec/SKILL.md` | P3 | +113 −0 | Added | None |
+| `templates/skills/write-spec/references/spec-template.md` | P3 | +99 −0 | Added | None |
+| `templates/skills/write-spec/scripts/gather-context.ps1` | P2 | +72 −0 | Added | None |
+| `templates/skills/write-spec/scripts/gather-context.sh` | P2 | +90 −0 | Added | None |
+| `README.md` | P3 | +19 −0 | Modified | None |
+| `CLAUDE.md` | P3 | +16 −0 | Modified | None |
+| `.documentation/specs/003-add-first-skill/*` | P3 | +3288 −0 | Added | None |
+
+---
+
+## Behavioral Changes
+
+| Change | Before | After | Intentional? | Risk |
+|--------|--------|-------|-------------|------|
+| `specify.md` step 4 | 8-step inline drafting procedure | Delegation block invoking write-spec skill | Yes (PR description) | Low — integration tests confirm structural parity; user-observable artifacts unchanged |
+| `_app.py` | harness_app, adapter_app | + skills_app | Yes | None — additive only |
+
+---
+
+## Approval Decision
+
+**Recommendation**: ⚠️ REQUEST CHANGES
+
+**Reasoning**: No critical or high issues found. M-01 (path resolution brittleness in production installs) is the most substantive finding — `_find_skills_root()` will silently fail with exit 0 when the package is installed as a wheel, which is a real deployment scenario. This is a silent failure with no user-visible diagnostic, making it harder to debug. M-02 (implicit CI coverage for new tests) is lower risk but worth an explicit confirmation.
+
+If the author is comfortable accepting M-01 as a tracked follow-up issue and M-02 as confirmed-covered by the existing CI `pytest tests/` run, the APPROVE disposition is defensible. The architecture is sound, the tests are excellent, and the spec lifecycle is Complete.
+
+**Estimated Rework Time**: M-01: 1–2 hours | M-02: 15 minutes | L-01: 2 minutes
+
+---
+
+```yaml
+findings:
+  - finding_id: pr-41-M-01
+    severity: medium
+    description: >
+      _find_skills_root() in skills.py uses a hardcoded 4-level __file__ parent
+      chain to locate templates/skills/. When the package is installed as a wheel,
+      the computed path does not exist. skills list exits 0 with "No skills found"
+      — silent failure, no diagnostic.
+    recommended_action: >
+      Add an os.environ.get("DEVSPARK_SKILLS_ROOT") override or locate
+      templates/skills/ via importlib.resources. At minimum, emit a warning when
+      the computed path does not exist rather than silently returning empty.
+    execution_mode: manual
+    status: open
+    outcome: ""
+
+  - finding_id: pr-41-M-02
+    severity: medium
+    description: >
+      Two new test modules (test_skill_contract.py, test_adapter_contract.py) are
+      added but CI workflow was not updated to explicitly include them. Coverage is
+      implicit if CI runs pytest tests/ broadly.
+    recommended_action: >
+      Confirm CI runs pytest tests/ (not a narrowed glob). If CI uses a test
+      matrix or include list, add the new files explicitly.
+    execution_mode: selective
+    status: open
+    outcome: ""
+
+  - finding_id: pr-41-L-01
+    severity: low
+    description: >
+      import sys on line 9 of skills.py is unused in the final file. Likely left
+      from an earlier draft.
+    recommended_action: >
+      Remove the unused import sys statement.
+    execution_mode: auto
+    status: open
+    outcome: ""
+
+  - finding_id: pr-41-CON-01
+    severity: low
+    description: >
+      §V Simplicity does not address the recurring pattern of CLI commands
+      discovering framework assets via __file__-relative paths, which breaks under
+      wheel installation.
+    recommended_action: >
+      Propose a constitution amendment via /devspark.evolve-constitution adding a
+      convention for asset discovery in installed CLI commands.
+    execution_mode: manual
+    status: open
+    outcome: ""
+```
+
+---
+
+*Review generated by devspark.pr-review v1.2*
+*Constitution-driven code review for DevSpark*
+*To re-review after fixes: `/devspark.pr-review #41 re-review`*
+*When addressing these findings, run `/devspark.address-pr-review 41`. The review file must be committed on its own — this rule is enforced by the prompt and can also be enforced by the optional pre-commit hook.*

--- a/.documentation/specs/pr-review/pr-41.md
+++ b/.documentation/specs/pr-review/pr-41.md
@@ -1,4 +1,4 @@
-# Pull Request Review: feat(skills): add first Agent Skill — write-spec with adapter contract, validation CLI, and specify refactor
+# Pull Request Review: feat(skills): add first Agent Skill - write-spec with adapter contract, validation CLI, and specify refactor
 
 ## Review Metadata
 
@@ -6,8 +6,8 @@
 - **Source Branch**: 003-add-first-skill
 - **Target Branch**: main
 - **Review Date**: 2026-05-20 04:00:00 UTC
-- **Last Updated**: 2026-05-20 05:00:00 UTC
-- **Reviewed Commit**: 75bcfe1a0aaf429455c975736fef0eb3c5502d56
+- **Last Updated**: 2026-05-20 13:43:03 UTC
+- **Reviewed Commit**: de097f80e859e1f61e139b44bd8da7d3e832eb55
 - **Reviewer**: devspark.pr-review
 - **Constitution Version**: 1.3.0 (amended 2026-04-30)
 
@@ -17,73 +17,75 @@
 |-----|--------|------|----------|------|--------|-----|-----|--------------|--------|
 | 1 | 75bcfe1 | 2026-05-20 | 0 | 0 | 2 | 1 | 1 | `pytest tests/test_skill_contract.py tests/test_adapter_contract.py` | pass (28/28) |
 | 2 | 7e8e22c | 2026-05-20 | 0 | 0 | 0 | 0 | 1 | `pytest tests/test_skill_contract.py tests/test_adapter_contract.py` | pass (28/28) |
+| 3 | de097f8 | 2026-05-20 | 0 | 1 | 0 | 0 | 1 | `pytest tests/test_skill_contract.py tests/test_adapter_contract.py` | pass (28/28) |
 
 ## PR Summary
 
 - **Author**: @markhazleton
 - **Created**: 2026-05-20
 - **Status**: OPEN
-- **Files Changed**: 21
-- **Commits**: 8
-- **Lines**: +4152 −26
+- **Files Changed**: 35
+- **Commits**: 12
+- **Lines**: +5196 -40
 
 ## Stats
 
 | Metric | Value |
 |--------|-------|
-| Files changed | 21 |
-| Lines added | +4152 |
-| Lines removed | −26 |
-| Net lines | +4126 |
-| Commit snapshot | `7e8e22c` |
+| Files changed | 35 |
+| Lines added | +5196 |
+| Lines removed | -40 |
+| Net lines | +5156 |
+| Commit snapshot | `de097f8` |
+
+*Collected from PR context and `git diff --numstat`. Rev 3 focused on the delta from previous review commit `c356d9a` to `de097f8`: 13 files, +744 -14.*
 
 ## Executive Summary
 
-- ✅ **Constitution Compliance**: PASS (8/8 principles checked)
-- 📋 **Spec Lifecycle**: Complete
-- 📝 **Task Completion**: 35/35 tasks complete
+- ✅ **Constitution Compliance**: WARN (7/8 principles pass; scope discipline fails for new Codex additions)
+- 📋 **Spec Lifecycle**: Complete for `003-add-first-skill`, but new Codex work is not covered by that spec
+- 📝 **Task Completion**: 35/35 tasks complete for the original skill feature
 - 🔒 **Security**: 0 issues found
-- 📊 **Code Quality**: 2 medium recommendations
-- 🧪 **Testing**: PASS (28 new tests pass; 159 total suite pass)
-- 📝 **Documentation**: PASS
-- 🏛️ **Constitution Improvements**: 1 CON finding
+- 📊 **Code Quality**: 0 new code-quality defects found in Rev 3
+- 🧪 **Testing**: PASS for baseline and focused checks
+- 📝 **Documentation**: PASS for markdown quality; scope/title/body need update
+- 🏛️ **Constitution Improvements**: 1 CON finding carried forward
 
-**Overall Assessment**: A well-executed feature that introduces the Agent Skills surface cleanly and without regressions. The dual-surface architecture (`command → adapter → skill`) is clearly documented and machine-enforced via tests. Two medium findings (path resolution brittleness in production installs, and missing CI wiring for the new test modules) are worth addressing before or shortly after merge.
+**Overall Assessment**: The new Codex quickstart, docs page, adapter, and manifest validation are technically sound and the focused tests pass. The problem is process and scope: commit `de097f8` adds first-class Codex support to a PR whose spec, task list, title, and description are for the first `write-spec` Agent Skill only.
 
-**Approval Recommendation**: ✅ APPROVE
-*M-01, M-02, L-01 resolved in 7e8e22c. Only CON-01 remains open (non-blocking constitution improvement for /devspark.evolve-constitution). No critical or high issues. All medium findings resolved.*
-
----
+**Approval Recommendation**: ⚠️ REQUEST CHANGES
+*APPROVE is blocked until H-01 is resolved by either moving the Codex work to a separate PR/spec or explicitly updating the PR/spec/tasks to include the Codex support delivered in `de097f8`.*
 
 ## Action Items
 
-### Immediate Actions (Blocking — must resolve before merge)
+*All findings ordered by severity. CRITICAL and HIGH items include the broken evidence and the fix.*
 
-None found.
+### Immediate Actions (Blocking - must resolve before merge)
+
+- [ ] **H-01** `.documentation/specs/003-add-first-skill/spec.md:17,85,178,217` - Rev 3 adds Codex support outside the approved feature scope.
+  - **Broken evidence**: the spec input is "Add Agent Skills support ... starting with a write-spec skill"; the review-focus section says this feature delivers one skill; FR-016 scopes command changes to `specify` only; out-of-scope excludes conversion or broad expansion beyond the pilot. Commit `de097f8` adds `.documentation/devspark-and-codex.md`, `quickstart/devspark_quickstart_codex.md`, `src/devspark_cli/harness/adapters/codex.py`, and Codex install-manifest behavior without corresponding spec or task coverage.
+  - **Fix**: choose one:
+    1. Move the Codex commit to a separate branch/PR with its own DevSpark spec and PR description, leaving PR #41 focused on `write-spec`.
+    2. Update `.documentation/specs/003-add-first-skill/spec.md`, `tasks.md`, gates, PR title, and PR body to explicitly include first-class Codex support, then re-run the required gates.
 
 ### Recommended Improvements
 
-- [x] **M-01** `src/devspark_cli/commands/skills.py:43-49` — `_find_skills_root()` uses `__file__`-relative path resolution that assumes a fixed directory depth (`commands/skills.py` → 4 parents = repo root). This breaks when the package is installed as a wheel (editable or non-editable) because the installed path is inside site-packages, not adjacent to `templates/`. The function silently returns a non-existent path and `skills list` reports "No skills found" with exit 0. — *Fixed in 7e8e22c: added DEVSPARK_SKILLS_ROOT env var override; emits diagnostic warning when computed path not found*
-- [x] **M-02** `tests/test_skill_contract.py`, `tests/test_adapter_contract.py` — CI workflow (`.github/workflows/`) was not updated to require these new test files in the required-check set. The tests run locally but are not guaranteed to gate PRs in CI unless CI already runs the full `pytest tests/` suite (which the workflow appears to do, but this is worth confirming). — *Fixed in 7e8e22c: added explicit 'Validate skill and adapter contracts' step to CI contract-validation job*
-- [x] **L-01** `src/devspark_cli/commands/skills.py:9` — `import sys` is present but `sys` is never referenced in the final file (it was likely left from an earlier draft). Remove the unused import. — *Fixed in 7e8e22c: removed import sys, added import os for env var read*
+None found.
 
-### Constitution Improvements (Non-blocking — feed into `/devspark.evolve-constitution`)
+### Constitution Improvements (Non-blocking - feed into `/devspark.evolve-constitution`)
 
-- [ ] **CON-01** — §V Simplicity does not currently address the path resolution pattern for CLI commands that discover framework assets. The `_find_skills_root()` pattern is a recurring problem (previously appeared in other commands). The constitution could benefit from a guiding principle or recommendation for how CLI commands locate `templates/` when installed as a package (e.g., using `importlib.resources` or an environment variable override).
-
----
+- [ ] **CON-01** - §V Simplicity does not currently address the path resolution pattern for CLI commands that discover framework assets. Keep this as a follow-up constitution improvement.
 
 ## What's Good
 
-- **Architecture**: The four-layer boundary (`command → adapter → skill → context scripts → artifact`) is explicit, well-documented in `ADAPTER-contract.md`, and machine-verified by `test_adapter_contract.py`. The responsibility table is authoritative and unambiguous.
-- **Test discipline**: Deliberate-violation fixture set in `test_skill_contract.py` is a strong addition — it verifies that each rule *fails* with a named rule message, not just that the valid case passes. This is the right level of test coverage for a validation contract.
-- **Graceful degradation**: Both context-gathering scripts (`gather-context.ps1`, `gather-context.sh`) always exit 0 and always emit valid JSON — the `skipped_context` pattern handles partial context cleanly without blocking the skill.
-- **Portability discipline**: SKILL.md body-scan in tests (T018/critic-008) mechanically prevents DevSpark-specific strings from leaking into portable skill bodies. This is a maintainability win that pays forward.
-- **Commit hygiene**: 5 clean phase-grouped commits follow the sub-phase ordering (2A→2B→2C→2D→sync), making the diff auditable per §VII.
-
----
+- The Codex harness adapter uses `codex exec --sandbox workspace-write -`; local `codex exec --help` confirms `-` reads instructions from stdin.
+- `validate_installation_manifest()` now validates against the selected agent's registered shim directory instead of hardcoding Copilot's `.github/agents/`.
+- The new Codex docs are linked from the docs site TOC, docs quickstart, docs home page, root README quickstart list, quickstart index, and the Codex quickstart itself.
+- Focused tests cover both the new adapter command shape and Codex `.codex/prompts/` manifest validation.
 
 ## Findings Detail
+
+*Stable IDs persist across re-reviews. Status updates instead of deleting.*
 
 ### Critical Issues (Blocking)
 
@@ -91,183 +93,153 @@ None found.
 
 ### High Priority Issues
 
-None found.
+| ID | Status | Principle | File:Line | Issue | Fix |
+|----|--------|-----------|-----------|-------|-----|
+| H-01 | 🔴 Open | §II Explicit Over Implied / Development Workflow | `.documentation/specs/003-add-first-skill/spec.md:17` | Rev 3 adds first-class Codex support that is not declared in the feature spec, tasks, PR title, or PR body. The current spec is for the `write-spec` Agent Skill pilot and explicitly emphasizes one-skill scope discipline. | Split Codex work into a dedicated PR/spec, or update the current spec/tasks/gates/PR body to explicitly include the Codex support and re-run gates. |
 
 ### Medium Priority Suggestions
 
 | ID | Status | Principle | File:Line | Issue | Recommendation |
 |----|--------|-----------|-----------|-------|----------------|
-| M-01 | ✅ Resolved | §V Simplicity | `src/devspark_cli/commands/skills.py:43` | `_find_skills_root()` hardcodes a 4-level `__file__` parent chain to reach the repo root. When installed as a wheel, `__file__` resolves inside site-packages and the computed path does not exist. `skills list` silently returns "No skills found" with exit 0 — no error, no diagnostic. | Fixed in 7e8e22c: DEVSPARK_SKILLS_ROOT env var override added; diagnostic warning emitted when computed path not found. |
-| M-02 | ✅ Resolved | §I Backward Compatibility | `.github/workflows/` (not changed) | Two new test modules (`test_skill_contract.py`, `test_adapter_contract.py`) are added but the CI workflow was not updated to explicitly include them in required checks. If CI runs `pytest tests/` broadly, they are covered — but this is implicit, not explicit. A future refactor of the CI matrix could silently drop them. | Fixed in 7e8e22c: explicit 'Validate skill and adapter contracts' pytest step added to CI contract-validation job. |
+| M-01 | ✅ Resolved | §V Simplicity | `src/devspark_cli/commands/skills.py:43` | `_find_skills_root()` hardcoded a `__file__` parent chain that breaks under wheel installs. | Fixed in 7e8e22c: `DEVSPARK_SKILLS_ROOT` override and diagnostic warning added. |
+| M-02 | ✅ Resolved | §I Backward Compatibility | `.github/workflows/tests.yml` | Skill and adapter contract tests were only implicitly covered by the full test suite. | Fixed in 7e8e22c: explicit contract-validation CI step added. |
 
 ### Low Priority Improvements
 
 | ID | Status | Principle | File:Line | Issue | Recommendation |
 |----|--------|-----------|-----------|-------|----------------|
-| L-01 | ✅ Resolved | §V Simplicity | `src/devspark_cli/commands/skills.py:9` | `import sys` on line 9 is unused — `sys` is not referenced anywhere in the final file. Likely left from an earlier draft iteration. | Fixed in 7e8e22c: removed import sys, added import os for DEVSPARK_SKILLS_ROOT env read. |
+| L-01 | ✅ Resolved | §V Simplicity | `src/devspark_cli/commands/skills.py:9` | Unused `import sys`. | Fixed in 7e8e22c. |
 
 ### Constitution Improvements
 
+*Findings where the code may be correct but the constitution needs updating. Feed these into `/devspark.evolve-constitution`.*
+
 | ID | Status | Section | Observation | Suggested Amendment |
 |----|--------|---------|-------------|---------------------|
-| CON-01 | 🔴 Open | §V Simplicity | The `_find_skills_root()` pattern of discovering framework assets via `__file__`-relative paths is a recurring problem in DevSpark CLI commands and is not addressed by any current principle. The constitution's §V guidance ("prefer conventions over configuration") does not resolve the install-time vs. source-checkout ambiguity. | Add a convention note to §V or a new §IX: "CLI commands that locate framework assets (templates/, skills/) MUST use an environment variable override (e.g., `DEVSPARK_ASSETS_ROOT`) or `importlib.resources` rather than `__file__`-relative paths, to ensure correct behavior after wheel installation." |
-
----
+| CON-01 | ➡️ Carried | §V Simplicity | The constitution does not address package asset discovery for installed CLI commands. | Add guidance requiring framework asset lookup via environment override or `importlib.resources` rather than brittle `__file__`-relative assumptions. |
 
 ## Constitution Alignment Details
 
 | Principle | Status | Evidence | Notes |
 |-----------|--------|----------|-------|
-| §I Backward Compatibility | ✅ Pass | 27 commands unchanged; specify.md test suite passes (2/2 integration tests) | Only `specify.md` refactored; user-observable UX unchanged |
-| §II Explicit Over Implied | ✅ Pass | ADAPTER-contract.md explicitly documents responsibility split; no silent scope inference | Input mapping table is authoritative and machine-tested |
-| §III Ownership Boundary | ✅ Pass | No writes to `.documentation/` by framework code; skill ships under `templates/skills/` | FR-017 enforced architecturally |
-| §IV Governance Authority | ✅ Pass | Constitution authority extends to new skill surface; validation rules derived from constitution | SKILL-validation-contract.md explicitly inherits constitution constraints |
-| §V Simplicity | ✅ Pass | Single skill, minimal adapter; DEVSPARK_SKILLS_ROOT override added for wheel installs | M-01 resolved in 7e8e22c; CON-01 (constitution gap) tracked separately |
-| §VI Platform Parity | ✅ Pass | `gather-context.ps1` and `gather-context.sh` both present; identical JSON schema and exit-0 contract verified | T017 run confirmed both scripts produce correct output |
-| §VII PR Review Artifact Commit Discipline | ✅ Pass | This review file is being committed separately from code changes | No co-mingling detected |
-| §VIII Markdown Quality | ✅ Pass | Zero markdownlint errors on all 7 new/modified markdown files | Baseline and post-implementation lint runs both clean |
-
----
+| §I Backward Compatibility | ✅ Pass | Existing skill/adapter tests still pass; Codex support is additive | No compatibility break found in Rev 3 |
+| §II Explicit Over Implied | ❌ Fail | Codex support is implemented without being declared in the current feature spec | H-01 |
+| §III Ownership Boundary | ✅ Pass | Runtime/install logic still avoids writing user-owned `.documentation/` during init | Docs additions are repo docs, not install payload writes |
+| §IV Governance Authority | ✅ Pass | Review catches the scope mismatch against constitution and spec lifecycle rules | No code governance bypass |
+| §V Simplicity | ✅ Pass | Codex adapter is a small `CommandLineAdapter` subclass; manifest validation generalizes existing behavior | CON-01 remains non-blocking |
+| §VI Platform Parity | ✅ Pass | Codex quickstart covers PowerShell and Bash script preferences; no Bash/PowerShell script pair changed | No parity issue found |
+| §VII PR Review Artifact Commit Discipline | ✅ Pass | Prior review file commits are isolated; Rev 3 code commit does not touch `pr-41.md` | No co-mingling detected |
+| §VIII Markdown Quality | ✅ Pass | Focused markdownlint command returned 0 errors | Full docs audit still has unrelated pre-existing broken links |
 
 ## Security Checklist
 
-- [x] No hardcoded secrets or credentials — scripts emit JSON with no auth tokens; no credentials in any file
-- [x] Input validation present where needed — `validate_skills()` validates all frontmatter fields before processing
-- [x] Authentication/authorization checks appropriate — N/A (no auth surface introduced)
-- [x] No SQL injection vulnerabilities — N/A (no database access)
-- [x] No XSS vulnerabilities — N/A (no web rendering)
-- [x] Dependencies reviewed for vulnerabilities — PyYAML ≥6.0 confirmed direct dependency; `yaml.safe_load()` used throughout (no arbitrary code execution risk from YAML parsing)
+- [x] No hardcoded secrets or credentials
+- [x] Input validation present where needed
+- [x] Authentication/authorization checks appropriate
+- [x] No SQL injection vulnerabilities
+- [x] No XSS vulnerabilities
+- [x] Dependencies reviewed for vulnerabilities
 
----
+Rev 3 introduces no auth, database, browser rendering, or dependency surface. Codex guidance explicitly says not to commit Codex auth files or tokens.
 
 ## Testing Coverage
 
-**Status**: ADEQUATE
+**Status**: ADEQUATE for implementation correctness; INADEQUATE for lifecycle scope until H-01 is resolved.
 
-- 19 contract tests (`TestSkillContract`) parametrized over all discovered skills; auto-extends as new skills are added
-- 6 deliberate-violation fixtures (`TestSkillContractViolationFixtures`) verify each rule fails with a named rule message
-- 9 adapter contract tests (`TestAdapterContractFiles`, `TestAdapterVariableContract`, `TestSpecifyReferencesSkill`) verify machine-enforced delegation contract
-- Integration tests for `specify.md` (2/2 pass unchanged after 2D refactor)
-- Full suite: 159 passed, 1 skipped, 0 failures
+Commands run for Rev 3:
+
+- `pytest tests/test_skill_contract.py tests/test_adapter_contract.py` - pass, 28/28
+- `python tests/test_harness_adapters_contract.py` - pass
+- `python tests/test_installation_manifest_contract.py` - pass
+- `python -m py_compile src/devspark_cli/harness/adapters/codex.py src/devspark_cli/_template.py src/devspark_cli/commands/init.py` - pass
+- `npx markdownlint-cli2 .documentation/devspark-and-codex.md .documentation/quickstart.md quickstart/devspark_quickstart_codex.md README.md quickstart/README.md` - pass, 0 errors
+
+`python tests/test_documentation_audit.py` was not used as a blocking Rev 3 signal because it fails on pre-existing broken links outside this change, including `.documentation/index.md -> validation-matrix.md` and archived release/spec links.
 
 ## Test Inventory
 
 | File | Main | Branch | Delta | Justification |
 |------|------|--------|-------|---------------|
-| `tests/test_skill_contract.py` | 0 | 19 | +19 | New — full contract coverage for write-spec |
-| `tests/test_adapter_contract.py` | 0 | 9 | +9 | New — delegation contract verification |
-| **Total** | 0 | 28 | +28 | |
+| `tests/test_installation_manifest_contract.py` | 0 | 1 script contract | +1 | New agent-specific manifest validation contract |
+| `tests/test_harness_adapters_contract.py` | 1 script contract | 1 script contract | 0 | Existing contract extended to include Codex command shape |
+| **Total** | 1 | 2 | +1 | |
 
 No tests removed.
 
----
-
 ## Documentation Status
 
-**Status**: ADEQUATE
+**Status**: PARTIAL
 
-- `README.md` updated with positioning statement and dual-surface model (FR-019)
-- `CLAUDE.md` updated with `command → invokes → skill` architecture note (FR-019)
-- `templates/skills/README.md` — landing page with dual-surface model summary
-- `templates/skills/ADAPTER-contract.md` — fully documented responsibility split, input/output mapping
-- `templates/skills/SKILL-validation-contract.md` — three-tier exit-code contract, prohibited keys, repair rules
-- `templates/skills/references/devspark-skills-guide.md` — step-by-step contributor walkthrough (SC-005)
-- `templates/skills/write-spec/references/spec-template.md` — spec structural reference
+The new Codex documentation itself is clear and markdownlint-clean. The PR-level documentation is stale:
 
----
+- PR title and body still describe a `write-spec` Agent Skill PR, not first-class Codex support.
+- `.documentation/specs/003-add-first-skill/spec.md` and `tasks.md` do not mention Codex.
+- The PR body still says "21 files changed, 4152 insertions(+), 26 deletions(-)" while PR context now reports 35 files and +5196 -40.
+
+These are rolled into H-01 because they are symptoms of the same lifecycle/scope mismatch.
 
 ## Changed Files Summary
 
 | File | Tier | Changes | Type | Findings |
 |------|------|---------|------|---------|
-| `src/devspark_cli/_app.py` | P1 | +3 −0 | Modified | None |
-| `src/devspark_cli/commands/skills.py` | P1 | +278 −0 | Added | M-01, L-01 |
-| `templates/commands/specify.md` | P1 | +28 −26 | Modified | None |
-| `tests/test_skill_contract.py` | P2 | +278 −0 | Added | None |
-| `tests/test_adapter_contract.py` | P2 | +100 −0 | Added | M-02 |
-| `templates/skills/ADAPTER-contract.md` | P3 | +142 −0 | Added | None |
-| `templates/skills/SKILL-validation-contract.md` | P3 | +146 −0 | Added | None |
-| `templates/skills/README.md` | P3 | +64 −0 | Added | None |
-| `templates/skills/references/devspark-skills-guide.md` | P3 | +313 −0 | Added (pre-existing stub completed) | None |
-| `templates/skills/write-spec/SKILL.md` | P3 | +113 −0 | Added | None |
-| `templates/skills/write-spec/references/spec-template.md` | P3 | +99 −0 | Added | None |
-| `templates/skills/write-spec/scripts/gather-context.ps1` | P2 | +72 −0 | Added | None |
-| `templates/skills/write-spec/scripts/gather-context.sh` | P2 | +90 −0 | Added | None |
-| `README.md` | P3 | +19 −0 | Modified | None |
-| `CLAUDE.md` | P3 | +16 −0 | Modified | None |
-| `.documentation/specs/003-add-first-skill/*` | P3 | +3288 −0 | Added | None |
-
----
+| `.documentation/devspark-and-codex.md` | P3 | +192 -0 | Added | H-01 (scope) |
+| `quickstart/devspark_quickstart_codex.md` | P3 | +420 -0 | Added | H-01 (scope) |
+| `src/devspark_cli/_template.py` | P1 | +25 -9 | Modified | None |
+| `src/devspark_cli/commands/init.py` | P1 | +4 -3 | Modified | None |
+| `src/devspark_cli/harness/adapters/__init__.py` | P1 | +2 -0 | Modified | None |
+| `src/devspark_cli/harness/adapters/codex.py` | P1 | +14 -0 | Added | None |
+| `tests/test_harness_adapters_contract.py` | P2 | +8 -2 | Modified | None |
+| `tests/test_installation_manifest_contract.py` | P2 | +59 -0 | Added | None |
+| `.documentation/index.md` | P3 | +1 -0 | Modified | H-01 (scope) |
+| `.documentation/quickstart.md` | P3 | +9 -0 | Modified | H-01 (scope) |
+| `.documentation/toc.yml` | P3 | +2 -0 | Modified | H-01 (scope) |
+| `README.md` | P3 | +1 -0 | Modified | H-01 (scope) |
+| `quickstart/README.md` | P3 | +7 -0 | Modified | H-01 (scope) |
 
 ## Behavioral Changes
 
 | Change | Before | After | Intentional? | Risk |
 |--------|--------|-------|-------------|------|
-| `specify.md` step 4 | 8-step inline drafting procedure | Delegation block invoking write-spec skill | Yes (PR description) | Low — integration tests confirm structural parity; user-observable artifacts unchanged |
-| `_app.py` | harness_app, adapter_app | + skills_app | Yes | None — additive only |
-
----
+| `devspark adapter list` / harness adapter registry | No Codex harness adapter | `codex` adapter registered and executes `codex exec --sandbox workspace-write -` | Yes | Low technical risk; high lifecycle scope issue in this PR |
+| `devspark init --ai codex` manifest validation | Checked Copilot `.github/agents` shims regardless of selected agent | Checks selected agent command directory, including `.codex/prompts` | Yes | Low |
+| Codex `CODEX_HOME` next-step guidance | Suggested persistent `setx CODEX_HOME ...` on Windows | Suggests session-scoped `$env:CODEX_HOME = ...` only if needed | Yes | Low |
 
 ## Approval Decision
 
-**Recommendation**: ✅ APPROVE
+**Recommendation**: ⚠️ REQUEST CHANGES
 
-**Reasoning**: All medium and low findings resolved in 7e8e22c (M-01: env var override + diagnostic warning; M-02: explicit CI step; L-01: unused import removed). CON-01 is a non-blocking constitution improvement tracked for `/devspark.evolve-constitution`. No critical or high issues found. Architecture is sound, spec lifecycle is Complete, test suite is green.
+**Reasoning**: The original skill work remains sound and all previous medium/low findings are resolved. Rev 3 introduces technically reasonable Codex support, but it is not covered by the `003-add-first-skill` spec or task list and the PR title/body are now stale. Under §II and the Development Workflow requirement that features be spec-driven, this should not merge until the scope is explicit.
 
-**Estimated Rework Time**: N/A — all blocking/medium items resolved.
+**Estimated Rework Time**: 30-90 minutes if updating PR/spec/tasks/gates; 10-20 minutes if moving `de097f8` to a separate PR.
 
 ---
 
 ```yaml
 findings:
-  - finding_id: pr-41-M-01
-    severity: medium
+  - finding_id: pr-41-H-01
+    severity: high
     description: >
-      _find_skills_root() in skills.py uses a hardcoded 4-level __file__ parent
-      chain to locate templates/skills/. When the package is installed as a wheel,
-      the computed path does not exist. skills list exits 0 with "No skills found"
-      — silent failure, no diagnostic.
+      Commit de097f8 adds first-class Codex quickstart, docs, harness adapter,
+      and install-manifest support to PR #41, but the active spec and task list
+      are for the write-spec Agent Skill pilot only. The PR title/body are also
+      stale and do not describe the Codex scope.
     recommended_action: >
-      Add an os.environ.get("DEVSPARK_SKILLS_ROOT") override or locate
-      templates/skills/ via importlib.resources. At minimum, emit a warning when
-      the computed path does not exist rather than silently returning empty.
+      Either move the Codex commit to a dedicated PR with its own DevSpark spec,
+      or update the current spec, tasks, gates, PR title, and PR body to include
+      the Codex support, then re-run validation.
     execution_mode: manual
-    status: resolved
-    outcome: "Fixed in 7e8e22c: DEVSPARK_SKILLS_ROOT env var override added; diagnostic warning emitted when computed path not found."
-
-  - finding_id: pr-41-M-02
-    severity: medium
-    description: >
-      Two new test modules (test_skill_contract.py, test_adapter_contract.py) are
-      added but CI workflow was not updated to explicitly include them. Coverage is
-      implicit if CI runs pytest tests/ broadly.
-    recommended_action: >
-      Confirm CI runs pytest tests/ (not a narrowed glob). If CI uses a test
-      matrix or include list, add the new files explicitly.
-    execution_mode: selective
-    status: resolved
-    outcome: "Fixed in 7e8e22c: explicit 'Validate skill and adapter contracts' pytest step added to CI contract-validation job in .github/workflows/tests.yml."
-
-  - finding_id: pr-41-L-01
-    severity: low
-    description: >
-      import sys on line 9 of skills.py is unused in the final file. Likely left
-      from an earlier draft.
-    recommended_action: >
-      Remove the unused import sys statement.
-    execution_mode: auto
-    status: resolved
-    outcome: "Fixed in 7e8e22c: removed import sys, added import os for DEVSPARK_SKILLS_ROOT env read."
+    status: open
+    outcome: ""
 
   - finding_id: pr-41-CON-01
     severity: low
     description: >
       §V Simplicity does not address the recurring pattern of CLI commands
-      discovering framework assets via __file__-relative paths, which breaks under
-      wheel installation.
+      discovering framework assets via package-relative paths, which can break
+      under wheel installation.
     recommended_action: >
-      Propose a constitution amendment via /devspark.evolve-constitution adding a
-      convention for asset discovery in installed CLI commands.
+      Propose a constitution amendment via /devspark.evolve-constitution adding
+      a convention for framework asset discovery in installed CLI commands.
     execution_mode: manual
     status: open
     outcome: ""
@@ -278,4 +250,4 @@ findings:
 *Review generated by devspark.pr-review v1.2*
 *Constitution-driven code review for DevSpark*
 *To re-review after fixes: `/devspark.pr-review #41 re-review`*
-*When addressing these findings, run `/devspark.address-pr-review 41`. The review file must be committed on its own — this rule is enforced by the prompt and can also be enforced by the optional pre-commit hook.*
+*When addressing these findings, run `/devspark.address-pr-review 41`. The review file must be committed on its own - this rule is enforced by the prompt and can also be enforced by the optional pre-commit hook.*

--- a/.documentation/specs/pr-review/pr-41.md
+++ b/.documentation/specs/pr-review/pr-41.md
@@ -6,7 +6,7 @@
 - **Source Branch**: 003-add-first-skill
 - **Target Branch**: main
 - **Review Date**: 2026-05-20 04:00:00 UTC
-- **Last Updated**: 2026-05-20 04:00:00 UTC
+- **Last Updated**: 2026-05-20 05:00:00 UTC
 - **Reviewed Commit**: 75bcfe1a0aaf429455c975736fef0eb3c5502d56
 - **Reviewer**: devspark.pr-review
 - **Constitution Version**: 1.3.0 (amended 2026-04-30)
@@ -16,6 +16,7 @@
 | Rev | Commit | Date | Critical | High | Medium | Low | CON | Test Command | Result |
 |-----|--------|------|----------|------|--------|-----|-----|--------------|--------|
 | 1 | 75bcfe1 | 2026-05-20 | 0 | 0 | 2 | 1 | 1 | `pytest tests/test_skill_contract.py tests/test_adapter_contract.py` | pass (28/28) |
+| 2 | 7e8e22c | 2026-05-20 | 0 | 0 | 0 | 0 | 1 | `pytest tests/test_skill_contract.py tests/test_adapter_contract.py` | pass (28/28) |
 
 ## PR Summary
 
@@ -34,7 +35,7 @@
 | Lines added | +4152 |
 | Lines removed | −26 |
 | Net lines | +4126 |
-| Commit snapshot | `75bcfe1` |
+| Commit snapshot | `7e8e22c` |
 
 ## Executive Summary
 
@@ -49,8 +50,8 @@
 
 **Overall Assessment**: A well-executed feature that introduces the Agent Skills surface cleanly and without regressions. The dual-surface architecture (`command → adapter → skill`) is clearly documented and machine-enforced via tests. Two medium findings (path resolution brittleness in production installs, and missing CI wiring for the new test modules) are worth addressing before or shortly after merge.
 
-**Approval Recommendation**: ⚠️ REQUEST CHANGES
-*Two medium findings (M-01, M-02) are worth resolving before merge. No critical or high issues found. If the author accepts these as post-merge follow-ups with filed issues, APPROVE is also defensible.*
+**Approval Recommendation**: ✅ APPROVE
+*M-01, M-02, L-01 resolved in 7e8e22c. Only CON-01 remains open (non-blocking constitution improvement for /devspark.evolve-constitution). No critical or high issues. All medium findings resolved.*
 
 ---
 
@@ -62,9 +63,9 @@ None found.
 
 ### Recommended Improvements
 
-- [ ] **M-01** `src/devspark_cli/commands/skills.py:43-49` — `_find_skills_root()` uses `__file__`-relative path resolution that assumes a fixed directory depth (`commands/skills.py` → 4 parents = repo root). This breaks when the package is installed as a wheel (editable or non-editable) because the installed path is inside site-packages, not adjacent to `templates/`. The function silently returns a non-existent path and `skills list` reports "No skills found" with exit 0.
-- [ ] **M-02** `tests/test_skill_contract.py`, `tests/test_adapter_contract.py` — CI workflow (`.github/workflows/`) was not updated to require these new test files in the required-check set. The tests run locally but are not guaranteed to gate PRs in CI unless CI already runs the full `pytest tests/` suite (which the workflow appears to do, but this is worth confirming).
-- [ ] **L-01** `src/devspark_cli/commands/skills.py:9` — `import sys` is present but `sys` is never referenced in the final file (it was likely left from an earlier draft). Remove the unused import.
+- [x] **M-01** `src/devspark_cli/commands/skills.py:43-49` — `_find_skills_root()` uses `__file__`-relative path resolution that assumes a fixed directory depth (`commands/skills.py` → 4 parents = repo root). This breaks when the package is installed as a wheel (editable or non-editable) because the installed path is inside site-packages, not adjacent to `templates/`. The function silently returns a non-existent path and `skills list` reports "No skills found" with exit 0. — *Fixed in 7e8e22c: added DEVSPARK_SKILLS_ROOT env var override; emits diagnostic warning when computed path not found*
+- [x] **M-02** `tests/test_skill_contract.py`, `tests/test_adapter_contract.py` — CI workflow (`.github/workflows/`) was not updated to require these new test files in the required-check set. The tests run locally but are not guaranteed to gate PRs in CI unless CI already runs the full `pytest tests/` suite (which the workflow appears to do, but this is worth confirming). — *Fixed in 7e8e22c: added explicit 'Validate skill and adapter contracts' step to CI contract-validation job*
+- [x] **L-01** `src/devspark_cli/commands/skills.py:9` — `import sys` is present but `sys` is never referenced in the final file (it was likely left from an earlier draft). Remove the unused import. — *Fixed in 7e8e22c: removed import sys, added import os for env var read*
 
 ### Constitution Improvements (Non-blocking — feed into `/devspark.evolve-constitution`)
 
@@ -96,14 +97,14 @@ None found.
 
 | ID | Status | Principle | File:Line | Issue | Recommendation |
 |----|--------|-----------|-----------|-------|----------------|
-| M-01 | 🔴 Open | §V Simplicity | `src/devspark_cli/commands/skills.py:43` | `_find_skills_root()` hardcodes a 4-level `__file__` parent chain to reach the repo root. When installed as a wheel, `__file__` resolves inside site-packages and the computed path does not exist. `skills list` silently returns "No skills found" with exit 0 — no error, no diagnostic. | Add an `os.environ.get("DEVSPARK_SKILLS_ROOT")` override, or locate `templates/skills/` relative to the package data declaration in `pyproject.toml` using `importlib.resources`. At minimum, add a fallback warning when the computed path does not exist. |
-| M-02 | 🔴 Open | §I Backward Compatibility | `.github/workflows/` (not changed) | Two new test modules (`test_skill_contract.py`, `test_adapter_contract.py`) are added but the CI workflow was not updated to explicitly include them in required checks. If CI runs `pytest tests/` broadly, they are covered — but this is implicit, not explicit. A future refactor of the CI matrix could silently drop them. | Confirm that the CI workflow runs `pytest tests/` (not a narrowed glob) and add a brief comment in the workflow file confirming skill tests are included. If CI uses a test matrix or file-pattern include list, add the new test files explicitly. |
+| M-01 | ✅ Resolved | §V Simplicity | `src/devspark_cli/commands/skills.py:43` | `_find_skills_root()` hardcodes a 4-level `__file__` parent chain to reach the repo root. When installed as a wheel, `__file__` resolves inside site-packages and the computed path does not exist. `skills list` silently returns "No skills found" with exit 0 — no error, no diagnostic. | Fixed in 7e8e22c: DEVSPARK_SKILLS_ROOT env var override added; diagnostic warning emitted when computed path not found. |
+| M-02 | ✅ Resolved | §I Backward Compatibility | `.github/workflows/` (not changed) | Two new test modules (`test_skill_contract.py`, `test_adapter_contract.py`) are added but the CI workflow was not updated to explicitly include them in required checks. If CI runs `pytest tests/` broadly, they are covered — but this is implicit, not explicit. A future refactor of the CI matrix could silently drop them. | Fixed in 7e8e22c: explicit 'Validate skill and adapter contracts' pytest step added to CI contract-validation job. |
 
 ### Low Priority Improvements
 
 | ID | Status | Principle | File:Line | Issue | Recommendation |
 |----|--------|-----------|-----------|-------|----------------|
-| L-01 | 🔴 Open | §V Simplicity | `src/devspark_cli/commands/skills.py:9` | `import sys` on line 9 is unused — `sys` is not referenced anywhere in the final file. Likely left from an earlier draft iteration. | Remove `import sys`. |
+| L-01 | ✅ Resolved | §V Simplicity | `src/devspark_cli/commands/skills.py:9` | `import sys` on line 9 is unused — `sys` is not referenced anywhere in the final file. Likely left from an earlier draft iteration. | Fixed in 7e8e22c: removed import sys, added import os for DEVSPARK_SKILLS_ROOT env read. |
 
 ### Constitution Improvements
 
@@ -121,7 +122,7 @@ None found.
 | §II Explicit Over Implied | ✅ Pass | ADAPTER-contract.md explicitly documents responsibility split; no silent scope inference | Input mapping table is authoritative and machine-tested |
 | §III Ownership Boundary | ✅ Pass | No writes to `.documentation/` by framework code; skill ships under `templates/skills/` | FR-017 enforced architecturally |
 | §IV Governance Authority | ✅ Pass | Constitution authority extends to new skill surface; validation rules derived from constitution | SKILL-validation-contract.md explicitly inherits constitution constraints |
-| §V Simplicity | ⚠️ Partial | Single skill, minimal adapter, no config layer — justified by interoperability goal | M-01: `_find_skills_root()` path resolution brittleness is a simplicity concern under production installs |
+| §V Simplicity | ✅ Pass | Single skill, minimal adapter; DEVSPARK_SKILLS_ROOT override added for wheel installs | M-01 resolved in 7e8e22c; CON-01 (constitution gap) tracked separately |
 | §VI Platform Parity | ✅ Pass | `gather-context.ps1` and `gather-context.sh` both present; identical JSON schema and exit-0 contract verified | T017 run confirmed both scripts produce correct output |
 | §VII PR Review Artifact Commit Discipline | ✅ Pass | This review file is being committed separately from code changes | No co-mingling detected |
 | §VIII Markdown Quality | ✅ Pass | Zero markdownlint errors on all 7 new/modified markdown files | Baseline and post-implementation lint runs both clean |
@@ -209,13 +210,11 @@ No tests removed.
 
 ## Approval Decision
 
-**Recommendation**: ⚠️ REQUEST CHANGES
+**Recommendation**: ✅ APPROVE
 
-**Reasoning**: No critical or high issues found. M-01 (path resolution brittleness in production installs) is the most substantive finding — `_find_skills_root()` will silently fail with exit 0 when the package is installed as a wheel, which is a real deployment scenario. This is a silent failure with no user-visible diagnostic, making it harder to debug. M-02 (implicit CI coverage for new tests) is lower risk but worth an explicit confirmation.
+**Reasoning**: All medium and low findings resolved in 7e8e22c (M-01: env var override + diagnostic warning; M-02: explicit CI step; L-01: unused import removed). CON-01 is a non-blocking constitution improvement tracked for `/devspark.evolve-constitution`. No critical or high issues found. Architecture is sound, spec lifecycle is Complete, test suite is green.
 
-If the author is comfortable accepting M-01 as a tracked follow-up issue and M-02 as confirmed-covered by the existing CI `pytest tests/` run, the APPROVE disposition is defensible. The architecture is sound, the tests are excellent, and the spec lifecycle is Complete.
-
-**Estimated Rework Time**: M-01: 1–2 hours | M-02: 15 minutes | L-01: 2 minutes
+**Estimated Rework Time**: N/A — all blocking/medium items resolved.
 
 ---
 
@@ -233,8 +232,8 @@ findings:
       templates/skills/ via importlib.resources. At minimum, emit a warning when
       the computed path does not exist rather than silently returning empty.
     execution_mode: manual
-    status: open
-    outcome: ""
+    status: resolved
+    outcome: "Fixed in 7e8e22c: DEVSPARK_SKILLS_ROOT env var override added; diagnostic warning emitted when computed path not found."
 
   - finding_id: pr-41-M-02
     severity: medium
@@ -246,8 +245,8 @@ findings:
       Confirm CI runs pytest tests/ (not a narrowed glob). If CI uses a test
       matrix or include list, add the new files explicitly.
     execution_mode: selective
-    status: open
-    outcome: ""
+    status: resolved
+    outcome: "Fixed in 7e8e22c: explicit 'Validate skill and adapter contracts' pytest step added to CI contract-validation job in .github/workflows/tests.yml."
 
   - finding_id: pr-41-L-01
     severity: low
@@ -257,8 +256,8 @@ findings:
     recommended_action: >
       Remove the unused import sys statement.
     execution_mode: auto
-    status: open
-    outcome: ""
+    status: resolved
+    outcome: "Fixed in 7e8e22c: removed import sys, added import os for DEVSPARK_SKILLS_ROOT env read."
 
   - finding_id: pr-41-CON-01
     severity: low

--- a/.documentation/toc.yml
+++ b/.documentation/toc.yml
@@ -9,6 +9,8 @@
       href: implementation-lifecycle.md
     - name: Quick Start
       href: quickstart.md
+    - name: DevSpark and Codex
+      href: devspark-and-codex.md
     - name: Other Ways to Get Started
       href: installation.md
     - name: Upgrade

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -64,6 +64,10 @@ jobs:
           python tests/test_adapter_doctor_contract.py
           python tests/test_hands_off_lifecycle_contract.py
 
+      - name: Validate skill and adapter contracts
+        run: |
+          pytest tests/test_skill_contract.py tests/test_adapter_contract.py -v --tb=short
+
   security-scan:
     runs-on: ubuntu-latest
     steps:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,9 +10,25 @@ Read `.documentation/memory/constitution.md` before making changes — it define
 
 This IS the DevSpark source repo. All `/devspark.*` commands resolve directly to `templates/commands/` — the source prompts you are iterating on. There is no `.devspark/defaults/commands/` copy. Edits to prompts take effect immediately.
 
+## Agent Skills Architecture
+
+DevSpark treats skills as portable capability packages within a governed lifecycle
+orchestration system. Commands invoke skills; DevSpark governs the lifecycle around
+them.
+
+Internal architecture: `command → invokes → skill → context scripts → artifact`
+
+- `templates/skills/` — Agent Skills surface: portable capability packages
+- `templates/skills/ADAPTER-contract.md` — How commands invoke skills
+- `templates/skills/SKILL-validation-contract.md` — Validation rules for SKILL.md files
+- `templates/skills/references/devspark-skills-guide.md` — Contributor walkthrough
+
+Skill validation: `devspark skills list` / `devspark skills validate [path]`
+
 ## Repository Structure
 
 - `templates/commands/` — 28 slash-command prompt files (the product)
+- `templates/skills/` — Agent Skills (portable capability packages)
 - `scripts/` — Context-gathering scripts (PowerShell + Bash)
 - `src/devspark_cli/` — Optional CLI for automated setup
 - `quickstart/` — Agent-specific bootstrap guides

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,7 +74,7 @@ Full list in `templates/commands/`.
 - Never overwrite `.documentation/` user artifacts during CLI operations
 
 <!-- DEVSPARK SHARED CONTEXT:START -->
-# AGENTS.md
+## AGENTS.md
 
 ## About DevSpark
 
@@ -697,4 +697,3 @@ When adding new agents:
 
 *This documentation should be updated whenever new agents are added to maintain accuracy and completeness.*
 <!-- DEVSPARK SHARED CONTEXT:END -->
-

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,3 +56,629 @@ Full list in `templates/commands/`.
 - Markdown linted via markdownlint-cli2 (config: `.markdownlint-cli2.jsonc`)
 - Scripts in both PowerShell and Bash (keep parity); context scripts support GitHub, AzDO, and GitLab
 - Never overwrite `.documentation/` user artifacts during CLI operations
+
+<!-- DEVSPARK SHARED CONTEXT:START -->
+# AGENTS.md
+
+## About DevSpark
+
+**DevSpark** is an Adaptive System Life Cycle Development (ASLCD) toolkit. It provides specification-driven workflows with constitution-powered quality gates, right-sized execution paths, and operational lifecycle guidance.
+
+**DevSpark CLI** is the command-line interface that bootstraps projects with the DevSpark framework. It sets up the necessary directory structures, templates, and AI agent integrations to support ASLCD workflows.
+
+The toolkit supports multiple AI coding assistants, allowing teams to use their preferred tools while maintaining consistent project structure and development practices.
+
+---
+
+## Canonical Layout and Platform Shims
+
+DevSpark uses a strict two-tier ownership model:
+
+- `.devspark/` holds framework-managed stock prompts, scripts, and templates
+- `.documentation/` holds repository-owned work product, overrides, constitutions, and specs
+
+Platform-specific directories (`.claude/`, `.github/`, `.cursor/`, etc.) contain only thin shims plus hydrated agent context.
+
+### Agent Registry (`agents-registry.json`)
+
+To prevent hardcoding AI agent identifiers across different workflow scripts and command templates, DevSpark leverages a centralized `agents-registry.json` file located in the repository root.
+
+**Key Features:**
+
+1. **Centralized Configuration**: Defines available agents (e.g., Copilot, Claude Code, Cursor) and their capabilities.
+2. **Cross-Editor Support**: Simplifies extending DevSpark to support new IDEs or agent implementations.
+3. **Workflow Integration**: Used dynamically by `create-pr` and other workspace scripts to understand which agent platforms are available or active.
+
+When adding a new AI assistant integration to DevSpark, simply append the agent's definition and configuration details to `agents-registry.json`.
+
+### File Layout
+
+```text
+`.devspark/`
+├── defaults/commands/           ← Stock command prompts (framework-managed)
+├── scripts/                     ← Stock helper scripts
+└── templates/                   ← Stock templates
+
+.documentation/
+├── commands/                    ← Team command overrides
+│   ├── devspark.specify.md
+│   ├── devspark.plan.md
+│   ├── devspark.implement.md
+│   ├── devspark.personalize.md
+│   └── ...
+├── {git-user}/                  ← Per-user personalized overrides
+│   └── commands/
+│       └── devspark.specify.md   ← Takes priority over shared default
+├── scripts/
+├── templates/
+├── memory/
+└── specs/
+
+.claude/commands/                ← Thin shims only
+.github/agents/                  ← Thin shims only
+.cursor/commands/                ← Thin shims only
+```
+
+### Shim Behavior
+
+Each platform shim:
+
+1. Resolves the current git user (`git config user.name`, slug-normalized)
+2. Checks for a personalized override at `.documentation/{git-user}/commands/devspark.{cmd}.md`
+3. Falls back to the shared default at `.documentation/commands/devspark.{cmd}.md`
+4. Falls back again to `.devspark/defaults/commands/devspark.{cmd}.md`
+5. Passes through user input (`$ARGUMENTS` / `{{args}}`) to the resolved prompt
+
+### Multi-User Personalization
+
+Team members can customize any command prompt without affecting others:
+
+- Run `/devspark.personalize {command}` to create a user-scoped copy
+- Personalized prompts live in `.documentation/{git-user}/commands/`
+- Committed to git so team members can share and review customizations
+- Delete the personalized file to revert to the shared default
+
+### Personalize Command
+
+The `/devspark.personalize` command creates per-user prompt overrides:
+
+```bash
+/devspark.personalize specify       # Personalize the /devspark.specify command
+/devspark.personalize plan          # Personalize the /devspark.plan command
+/devspark.personalize implement     # Personalize the /devspark.implement command
+```
+
+---
+
+## General practices
+
+- Any changes to `__init__.py` for the DevSpark CLI require a version rev in `pyproject.toml` and addition of entries to `CHANGELOG.md`.
+
+## Lightweight Workflow Commands
+
+These commands support the Adaptive System Life Cycle Development (ASLCD) approach, providing right-sized processes for tasks of varying complexity.
+
+### Quickfix Command
+
+The `/devspark.quickfix` command enables rapid fixes without full spec overhead:
+
+**Key Features:**
+
+1. **Auto-Classification**: Automatically classifies tasks as bug-fix, hotfix, minor-feature, config-change, or docs-update
+2. **Targeted Validation**: Only validates against constitution principles relevant to the task type
+3. **Lightweight Records**: Creates minimal documentation at `/.documentation/quickfixes/QF-{YYYY}-{NNN}.md`
+4. **Completion Tracking**: Supports marking quickfixes complete with commit/PR references
+5. **Scope Detection**: Warns when work expands beyond classification limits
+
+**Usage:**
+
+```bash
+/devspark.quickfix fix null pointer in UserService
+/devspark.quickfix urgent: payment timeout in checkout
+/devspark.quickfix complete QF-2026-001
+/devspark.quickfix list
+```
+
+### Release Command
+
+The `/devspark.release` command manages documentation lifecycle at release boundaries:
+
+**Key Features:**
+
+1. **Artifact Archival**: Archives completed specs and quickfixes to `/.documentation/releases/v{VERSION}/`
+2. **ADR Extraction**: Distills key architectural decisions from specs into ADR format
+3. **CHANGELOG Generation**: Auto-generates changelog entries from completed work
+4. **Version Calculation**: Auto-determines MAJOR/MINOR/PATCH based on content
+5. **Clean Slate**: Resets specs directory for next development cycle
+6. **Dry Run Mode**: Preview changes before committing
+
+**Usage:**
+
+```bash
+/devspark.release              # Auto-calculate version
+/devspark.release 2.0.0        # Explicit version
+/devspark.release --dry-run    # Preview only
+```
+
+### Harvest Command
+
+The `/devspark.harvest` command cleans up stale documentation and completed delivery artifacts while preserving useful knowledge in living docs:
+
+**Key Features:**
+
+1. **Knowledge-Preserving Cleanup**: Captures durable guidance in CHANGELOG, instructions, and living docs before archival
+2. **Documentation Triage**: Scores and classifies stale drafts, reviews, audits, backups, and legacy-root docs
+3. **Comment Rewriting**: Finds spec-linked code comments and rewrites them into self-contained explanations
+4. **Archive Safety**: Moves obsolete artifacts to `/.archive/` instead of deleting them
+5. **Approval Gate**: Requires an explicit user confirmation step before any edits or archival moves
+6. **Scan Mode**: Supports dry-run style inventory via `--scope=scan`
+
+**Usage:**
+
+```bash
+/devspark.harvest
+/devspark.harvest --scope=docs
+/devspark.harvest --scope=comments
+/devspark.harvest --scope=scan
+```
+
+### Constitution Evolution Command
+
+The `/devspark.evolve-constitution` command facilitates constitution amendments:
+
+**Key Features:**
+
+1. **Pattern Analysis**: Scans PR reviews and audits for recurring violation patterns
+2. **Gap Detection**: Identifies issues not mapped to existing principles
+3. **Proposal Generation**: Creates CAP (Constitution Amendment Proposal) documents
+4. **History Tracking**: Maintains amendment history at `/.documentation/memory/constitution-history.md`
+5. **Approval Workflow**: Supports approve/reject actions with reasons
+
+**Usage:**
+
+```bash
+/devspark.evolve-constitution                          # Full analysis
+/devspark.evolve-constitution --from-pr #123           # From specific PR
+/devspark.evolve-constitution suggest "API versioning" # Manual suggestion
+/devspark.evolve-constitution approve CAP-2026-001     # Approve proposal
+/devspark.evolve-constitution reject CAP-2026-002 "Too restrictive"
+```
+
+---
+
+## PR Review Command
+
+The `/devspark.pr-review` command is a special command that works independently of the spec-driven development workflow:
+
+### Unique Characteristics
+
+1. **Constitution-Only**: Requires only `/.documentation/memory/constitution.md` - no spec, plan, or tasks needed
+2. **Repository-Wide**: Works for any PR in any branch (main, develop, feature, etc.)
+3. **Persistent Storage**: Reviews saved to `/.documentation/specs/pr-review/pr-{id}.md` with metadata
+4. **Version Tracking**: Tracks commit SHA and timestamp for each review
+5. **Update Logic**: Handles multiple reviews of same PR with history
+6. **GitHub Integration**: Uses GitHub CLI (`gh`) for PR data extraction
+
+### Implementation Notes
+
+- **Script**: Uses dedicated `get-pr-context.{sh,ps1}` scripts (not `check-prerequisites`)
+- **No Feature Context**: Doesn't require feature branch or spec directory
+- **JSON Output**: Scripts return PR metadata including commit SHA, files changed, diff availability
+- **Error Handling**: Graceful degradation when constitution missing or GitHub CLI unavailable
+
+### Agent Integration
+
+When adding new agents, include `/devspark.pr-review` following the same pattern as other commands:
+
+- Markdown format for most agents
+- TOML format for Gemini/Qwen
+- Script placeholders: `{SCRIPT}` replaced with `get-pr-context` script path
+- Argument placeholder: `$ARGUMENTS` for PR number
+
+See `templates/commands/pr-review.md` for the canonical template.
+
+---
+
+## Adding New Agent Support
+
+This section explains how to add support for new AI agents/assistants to the DevSpark CLI. Use this guide as a reference when integrating new AI tools into the Spec-Driven Development workflow.
+
+### Overview
+
+Specify supports multiple AI agents by generating agent-specific command files and directory structures when initializing projects. Each agent has its own conventions for:
+
+- **Command file formats** (Markdown, TOML, etc.)
+- **Directory structures** (`.claude/commands/`, `.windsurf/workflows/`, etc.)
+- **Command invocation patterns** (slash commands, CLI tools, etc.)
+- **Argument passing conventions** (`$ARGUMENTS`, `{{args}}`, etc.)
+
+### Current Supported Agents
+
+| Agent                      | Directory              | Format   | CLI Tool        | Description                 |
+| -------------------------- | ---------------------- | -------- | --------------- | --------------------------- |
+| **Claude Code**            | `.claude/commands/`    | Markdown | `claude`        | Anthropic's Claude Code CLI |
+| **Gemini CLI**             | `.gemini/commands/`    | TOML     | `gemini`        | Google's Gemini CLI         |
+| **GitHub Copilot**         | `.github/agents/`      | Markdown | N/A (IDE-based) | GitHub Copilot in VS Code   |
+| **Cursor**                 | `.cursor/commands/`    | Markdown | `cursor-agent`  | Cursor CLI                  |
+| **Qwen Code**              | `.qwen/commands/`      | TOML     | `qwen`          | Alibaba's Qwen Code CLI     |
+| **opencode**               | `.opencode/command/`   | Markdown | `opencode`      | opencode CLI                |
+| **Codex CLI**              | `.codex/commands/`     | Markdown | `codex`         | Codex CLI                   |
+| **Windsurf**               | `.windsurf/workflows/` | Markdown | N/A (IDE-based) | Windsurf IDE workflows      |
+| **Kilo Code**              | `.kilocode/rules/`     | Markdown | N/A (IDE-based) | Kilo Code IDE               |
+| **Auggie CLI**             | `.augment/rules/`      | Markdown | `auggie`        | Auggie CLI                  |
+| **Roo Code**               | `.roo/rules/`          | Markdown | N/A (IDE-based) | Roo Code IDE                |
+| **CodeBuddy CLI**          | `.codebuddy/commands/` | Markdown | `codebuddy`     | CodeBuddy CLI               |
+| **Qoder CLI**              | `.qoder/commands/`     | Markdown | `qodercli`      | Qoder CLI                   |
+| **Amazon Q Developer CLI** | `.amazonq/prompts/`    | Markdown | `q`             | Amazon Q Developer CLI      |
+| **Amp**                    | `.agents/commands/`    | Markdown | `amp`           | Amp CLI                     |
+| **SHAI**                   | `.shai/commands/`      | Markdown | `shai`          | SHAI CLI                    |
+| **IBM Bob**                | `.bob/commands/`       | Markdown | N/A (IDE-based) | IBM Bob IDE                 |
+
+### Step-by-Step Integration Guide
+
+Follow these steps to add a new agent (using a hypothetical new agent as an example):
+
+#### 1. Add to the shared registry
+
+**IMPORTANT**: Use the actual CLI tool name as the key, not a shortened version.
+
+Add the new agent to `agents-registry.json`. This is the single source of truth for CLI setup, release packaging, and context generation:
+
+```json
+{
+  "key": "new-agent-cli",
+  "name": "New Agent Display Name",
+  "folder": ".newagent/",
+  "context_file": "AGENTS.md",
+  "requires_cli": true,
+  "install_url": "https://example.com/install",
+  "release": {
+    "commands_dir": ".newagent/commands",
+    "extension": "md",
+    "arg_format": "$ARGUMENTS"
+  }
+}
+```
+
+**Key Design Principle**: The dictionary key should match the actual executable name that users install. For example:
+
+- ✅ Use `"cursor-agent"` because the CLI tool is literally called `cursor-agent`
+- ❌ Don't use `"cursor"` as a shortcut if the tool is `cursor-agent`
+
+This eliminates the need for special-case mappings throughout the codebase.
+
+**Field Explanations**:
+
+- `name`: Human-readable display name shown to users
+- `folder`: Directory where agent-specific files are stored (relative to project root)
+- `install_url`: Installation documentation URL (set to `None` for IDE-based agents)
+- `requires_cli`: Whether the agent requires a CLI tool check during initialization
+
+#### 2. Update CLI Help Text
+
+Update the `--ai` parameter help text in the `init()` command to include the new agent:
+
+```python
+ai_assistant: str = typer.Option(None, "--ai", help="AI assistant to use: claude, gemini, copilot, cursor-agent, qwen, opencode, codex, windsurf, kilocode, auggie, codebuddy, new-agent-cli, or q"),
+```
+
+Also update any function docstrings, examples, and error messages that list available agents.
+
+#### 3. Update README Documentation
+
+Update the **Supported AI Agents** section in `README.md` to include the new agent:
+
+- Add the new agent to the table with appropriate support level (Full/Partial)
+- Include the agent's official website link
+- Add any relevant notes about the agent's implementation
+- Ensure the table formatting remains aligned and consistent
+
+#### 4. Update Release Package Script
+
+Modify `.github/workflows/scripts/create-release-packages.sh`:
+
+##### Add to ALL_AGENTS array
+
+```bash
+ALL_AGENTS=(claude gemini copilot cursor-agent qwen opencode windsurf q)
+```
+
+##### Add case statement for directory structure
+
+```bash
+case $agent in
+  # ... existing cases ...
+  windsurf)
+    mkdir -p "$base_dir/.windsurf/workflows"
+    generate_commands windsurf md "\$ARGUMENTS" "$base_dir/.windsurf/workflows" "$script" ;;
+esac
+```
+
+#### 4. Update GitHub Release Script
+
+Modify `.github/workflows/scripts/create-github-release.sh` to include the new agent's packages:
+
+```bash
+gh release create "$VERSION" \
+  # ... existing packages ...
+  .genreleases/devspark-template-windsurf-sh-"$VERSION".zip \
+  .genreleases/devspark-template-windsurf-ps-"$VERSION".zip \
+  # Add new agent packages here
+```
+
+#### 5. Update Agent Context Scripts
+
+##### Bash script (`scripts/bash/update-agent-context.sh`)
+
+Add file variable:
+
+```bash
+WINDSURF_FILE="$REPO_ROOT/.windsurf/rules/devspark-rules.md"
+```
+
+Add to case statement:
+
+```bash
+case "$AGENT_TYPE" in
+  # ... existing cases ...
+  windsurf) update_agent_file "$WINDSURF_FILE" "Windsurf" ;;
+  "")
+    # ... existing checks ...
+    [ -f "$WINDSURF_FILE" ] && update_agent_file "$WINDSURF_FILE" "Windsurf";
+    # Update default creation condition
+    ;;
+esac
+```
+
+##### PowerShell script (`scripts/powershell/update-agent-context.ps1`)
+
+Add file variable:
+
+```powershell
+$windsurfFile = Join-Path $repoRoot '.windsurf/rules/devspark-rules.md'
+```
+
+Add to switch statement:
+
+```powershell
+switch ($AgentType) {
+    # ... existing cases ...
+    'windsurf' { Update-AgentFile $windsurfFile 'Windsurf' }
+    '' {
+        foreach ($pair in @(
+            # ... existing pairs ...
+            @{file=$windsurfFile; name='Windsurf'}
+        )) {
+            if (Test-Path $pair.file) { Update-AgentFile $pair.file $pair.name }
+        }
+        # Update default creation condition
+    }
+}
+```
+
+#### 6. Update CLI Tool Checks (Optional)
+
+For agents that require CLI tools, add checks in the `check()` command and agent validation:
+
+```python
+# In check() command
+tracker.add("windsurf", "Windsurf IDE (optional)")
+windsurf_ok = check_tool_for_tracker("windsurf", "https://windsurf.com/", tracker)
+
+# In init validation (only if CLI tool required)
+elif selected_ai == "windsurf":
+    if not check_tool("windsurf", "Install from: https://windsurf.com/"):
+        console.print("[red]Error:[/red] Windsurf CLI is required for Windsurf projects")
+        agent_tool_missing = True
+```
+
+**Note**: CLI tool checks are now handled automatically based on the `requires_cli` field in AGENT_CONFIG. No additional code changes needed in the `check()` or `init()` commands - they automatically loop through AGENT_CONFIG and check tools as needed.
+
+## Important Design Decisions
+
+### Using Actual CLI Tool Names as Keys
+
+**CRITICAL**: When adding a new agent to AGENT_CONFIG, always use the **actual executable name** as the dictionary key, not a shortened or convenient version.
+
+**Why this matters:**
+
+- The `check_tool()` function uses `shutil.which(tool)` to find executables in the system PATH
+- If the key doesn't match the actual CLI tool name, you'll need special-case mappings throughout the codebase
+- This creates unnecessary complexity and maintenance burden
+
+**Example - The Cursor Lesson:**
+
+❌ **Wrong approach** (requires special-case mapping):
+
+```python
+AGENT_CONFIG = {
+    "cursor": {  # Shorthand that doesn't match the actual tool
+        "name": "Cursor",
+        # ...
+    }
+}
+
+# Then you need special cases everywhere:
+cli_tool = agent_key
+if agent_key == "cursor":
+    cli_tool = "cursor-agent"  # Map to the real tool name
+```
+
+✅ **Correct approach** (no mapping needed):
+
+```python
+AGENT_CONFIG = {
+    "cursor-agent": {  # Matches the actual executable name
+        "name": "Cursor",
+        # ...
+    }
+}
+
+# No special cases needed - just use agent_key directly!
+```
+
+**Benefits of this approach:**
+
+- Eliminates special-case logic scattered throughout the codebase
+- Makes the code more maintainable and easier to understand
+- Reduces the chance of bugs when adding new agents
+- Tool checking "just works" without additional mappings
+
+#### 7. Update Devcontainer files (Optional)
+
+For agents that have VS Code extensions or require CLI installation, update the devcontainer configuration files:
+
+##### VS Code Extension-based Agents
+
+For agents available as VS Code extensions, add them to `.devcontainer/devcontainer.json`:
+
+```json
+{
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        // ... existing extensions ...
+        // [New Agent Name]
+        "[New Agent Extension ID]"
+      ]
+    }
+  }
+}
+```
+
+##### CLI-based Agents
+
+For agents that require CLI tools, add installation commands to `.devcontainer/post-create.sh`:
+
+```bash
+#!/bin/bash
+
+# Existing installations...
+
+echo -e "\n🤖 Installing [New Agent Name] CLI..."
+# run_command "npm install -g [agent-cli-package]@latest" # Example for node-based CLI
+# or other installation instructions (must be non-interactive and compatible with Linux Debian "Trixie" or later)...
+echo "✅ Done"
+
+```
+
+**Quick Tips:**
+
+- **Extension-based agents**: Add to the `extensions` array in `devcontainer.json`
+- **CLI-based agents**: Add installation scripts to `post-create.sh`
+- **Hybrid agents**: May require both extension and CLI installation
+- **Test thoroughly**: Ensure installations work in the devcontainer environment
+
+## Agent Categories
+
+### CLI-Based Agents
+
+Require a command-line tool to be installed:
+
+- **Claude Code**: `claude` CLI
+- **Gemini CLI**: `gemini` CLI
+- **Cursor**: `cursor-agent` CLI
+- **Qwen Code**: `qwen` CLI
+- **opencode**: `opencode` CLI
+- **Amazon Q Developer CLI**: `q` CLI
+- **CodeBuddy CLI**: `codebuddy` CLI
+- **Qoder CLI**: `qodercli` CLI
+- **Amp**: `amp` CLI
+- **SHAI**: `shai` CLI
+
+### IDE-Based Agents
+
+Work within integrated development environments:
+
+- **GitHub Copilot**: Built into VS Code/compatible editors
+- **Windsurf**: Built into Windsurf IDE
+- **IBM Bob**: Built into IBM Bob IDE
+
+## Command File Formats
+
+### Markdown Format
+
+Used by: Claude, Cursor, opencode, Windsurf, Amazon Q Developer, Amp, SHAI, IBM Bob
+
+**Standard format:**
+
+```markdown
+---
+description: "Command description"
+---
+
+Command content with {SCRIPT} and $ARGUMENTS placeholders.
+```
+
+**GitHub Copilot Chat Mode format:**
+
+```markdown
+---
+description: "Command description"
+mode: devspark.command-name
+---
+
+Command content with {SCRIPT} and $ARGUMENTS placeholders.
+```
+
+### TOML Format
+
+Used by: Gemini, Qwen
+
+```toml
+description = "Command description"
+
+prompt = """
+Command content with {SCRIPT} and {{args}} placeholders.
+"""
+```
+
+## Directory Conventions
+
+- **CLI agents**: Usually `.<agent-name>/commands/`
+- **IDE agents**: Follow IDE-specific patterns:
+  - Copilot: `.github/agents/`
+  - Cursor: `.cursor/commands/`
+  - Windsurf: `.windsurf/workflows/`
+
+## Argument Patterns
+
+Different agents use different argument placeholders:
+
+- **Markdown/prompt-based**: `$ARGUMENTS`
+- **TOML-based**: `{{args}}`
+- **Script placeholders**: `{SCRIPT}` (replaced with actual script path)
+- **Agent placeholders**: `__AGENT__` (replaced with agent name)
+
+## Testing New Agent Integration
+
+1. **Build test**: Run package creation script locally
+2. **CLI test**: Test `devspark init --ai <agent>` command
+3. **File generation**: Verify correct directory structure and files
+4. **Command validation**: Ensure generated commands work with the agent
+5. **Context update**: Test agent context update scripts
+
+## Common Pitfalls
+
+1. **Using shorthand keys instead of actual CLI tool names**: Always use the actual executable name as the AGENT_CONFIG key (e.g., `"cursor-agent"` not `"cursor"`). This prevents the need for special-case mappings throughout the codebase.
+2. **Forgetting update scripts**: Both bash and PowerShell scripts must be updated when adding new agents.
+3. **Incorrect `requires_cli` value**: Set to `True` only for agents that actually have CLI tools to check; set to `False` for IDE-based agents.
+4. **Wrong argument format**: Use correct placeholder format for each agent type (`$ARGUMENTS` for Markdown, `{{args}}` for TOML).
+5. **Directory naming**: Follow agent-specific conventions exactly (check existing agents for patterns).
+6. **Help text inconsistency**: Update all user-facing text consistently (help strings, docstrings, README, error messages).
+
+## Future Considerations
+
+When adding new agents:
+
+- Consider the agent's native command/workflow patterns
+- Ensure compatibility with the Spec-Driven Development process
+- Document any special requirements or limitations
+- Update this guide with lessons learned
+- Verify the actual CLI tool name before adding to AGENT_CONFIG
+
+---
+
+*This documentation should be updated whenever new agents are added to maintain accuracy and completeness.*
+<!-- DEVSPARK SHARED CONTEXT:END -->
+

--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Point your AI agent at the quickstart prompt for your platform:
 - [GitHub Copilot](quickstart/devspark_quickstart_copilot.md)
 - [Claude Code](quickstart/devspark_quickstart_claudecode.md)
 - [Cursor](quickstart/devspark_quickstart_cursor.md)
+- [Codex](quickstart/devspark_quickstart_codex.md)
 - [Any other agent](quickstart/devspark_quickstart_generic.md)
 
 The agent asks a few questions, then pulls and installs all DevSpark prompts.

--- a/README.md
+++ b/README.md
@@ -29,6 +29,32 @@ devspark/
 └── .documentation/       ← Guides, media, and GitHub Pages site
 ```
 
+## Agent Skills
+
+DevSpark treats skills as portable capability packages within a governed lifecycle
+orchestration system. Commands invoke skills; DevSpark governs the lifecycle around
+them.
+
+The dual-surface model:
+
+```text
+command -> adapter -> skill -> context scripts -> agent reasoning -> artifact
+```
+
+- **Slash-commands** (`templates/commands/`) own DevSpark-specific lifecycle behavior:
+  route classification, branch creation, multi-app scoping, artifact placement, and
+  gate enforcement.
+- **Agent Skills** (`templates/skills/`) own portable capability instructions that
+  run in any skills-compatible client without DevSpark installed.
+
+The adapter contract (`templates/skills/ADAPTER-contract.md`) defines how a command
+invokes a skill. The skill validation contract
+(`templates/skills/SKILL-validation-contract.md`) defines the rules every `SKILL.md`
+must satisfy. See `templates/skills/references/devspark-skills-guide.md` for the
+contributor walkthrough for adding new skills.
+
+---
+
 ## Get Started
 
 DevSpark v2 ships three flagship aliases that are the recommended entrypoints for every new feature. Run them via `devspark run <alias>` (or your agent's `/devspark.run` slash command):

--- a/quickstart/README.md
+++ b/quickstart/README.md
@@ -9,6 +9,7 @@ Install DevSpark into any repository by pointing your AI agent at the right quic
 | **GitHub Copilot** | [`devspark_quickstart_copilot.md`](devspark_quickstart_copilot.md) |
 | **Claude Code** | [`devspark_quickstart_claudecode.md`](devspark_quickstart_claudecode.md) |
 | **Cursor** | [`devspark_quickstart_cursor.md`](devspark_quickstart_cursor.md) |
+| **Codex** | [`devspark_quickstart_codex.md`](devspark_quickstart_codex.md) |
 | **Any other agent** | [`devspark_quickstart_generic.md`](devspark_quickstart_generic.md) |
 
 ## How It Works
@@ -43,6 +44,12 @@ Example (Claude Code):
 
 ```text
 /devspark Follow the instructions at https://raw.githubusercontent.com/markhazleton/devspark/main/quickstart/devspark_quickstart_claudecode.md
+```
+
+Example (Codex):
+
+```text
+Follow the instructions at https://raw.githubusercontent.com/markhazleton/devspark/main/quickstart/devspark_quickstart_codex.md
 ```
 
 ## What Gets Installed

--- a/quickstart/devspark_quickstart_codex.md
+++ b/quickstart/devspark_quickstart_codex.md
@@ -1,0 +1,420 @@
+# DevSpark Quickstart — Codex
+
+You are bootstrapping **DevSpark**, a spec-driven development process, into this repository.
+No CLI installation is required. You will pull prompt files from the DevSpark repo and place them in the correct directories.
+
+This guide is tailored for OpenAI Codex. Codex should receive durable repository guidance through `AGENTS.md`, and DevSpark command shims should be placed in `.codex/prompts/` for Codex CLI builds that discover custom prompt files.
+
+For best practices after installation, see [DevSpark and Codex](../.documentation/devspark-and-codex.md).
+
+## Step 1: Gather Project Context
+
+Ask only the install-critical question before proceeding:
+
+1. **Script preference** — Does this project use **PowerShell** (`ps`) or **Bash** (`sh`) for scripts? Default to PowerShell on Windows and Bash elsewhere.
+
+Wait for answers before continuing.
+
+Codex compatibility notes:
+
+- Keep `CODEX_HOME` unchanged unless prompt discovery fails.
+- If `CODEX_HOME` is needed, set it only for the current shell/session.
+- Do not write Codex auth files or tokens into the repository.
+
+---
+
+## Step 2: Detect Existing Installation
+
+Before creating anything, check for prior legacy / DevSpark installations:
+
+| Check for | What it means |
+|---|---|
+| `.devspark/` exists | **DevSpark already installed.** See "Version Check" below. |
+| `.documentation/` exists | **User artifacts exist.** Preserve everything — never overwrite. |
+| `.specify/` exists | **Legacy layout detected.** Needs migration. |
+| `.documentation/defaults/commands/` exists | **Pre-separation DevSpark.** Stock commands need to move to `.devspark/`. |
+| Root `memory/` (without `.documentation/memory/`) | **Legacy structure.** Needs migration. |
+| Root `scripts/` or `templates/` (without `.devspark/scripts/`) | **Legacy structure.** Needs migration. |
+| `.codex/prompts/specify.*.md` files | **Legacy Codex shims detected.** Rename to `devspark.*` prefix. |
+
+**If nothing is found**, skip ahead to Step 3.
+
+### Migration: `.specify/` (legacy layout)
+
+Tell the user what you found and ask for confirmation before proceeding.
+
+1. Copy `.specify/memory/*` → `.documentation/memory/` (skip files that already exist at destination)
+2. Copy `.specify/specs/*` → `.documentation/specs/` (skip files that already exist)
+3. Copy any `.specify/` root-level `.md` files → `.documentation/` (skip files that already exist)
+4. Rename `.specify/` → `.specify.old/` (preserve as backup)
+5. Report: "Migrated .specify/ → .documentation/. Backup at .specify.old/"
+
+### Migration: `.documentation/defaults/` (pre-separation DevSpark)
+
+1. Create `.devspark/` directory structure
+2. Move `.documentation/defaults/commands/*` → `.devspark/defaults/commands/`
+3. Move `.documentation/defaults/templates/*` → `.devspark/templates/` if present
+4. Move `.documentation/scripts/*` → `.devspark/scripts/` (only stock DevSpark scripts with framework header comments — leave user-created scripts)
+5. Move `.documentation/templates/*` → `.devspark/templates/` (only stock DevSpark templates)
+6. Delete empty `.documentation/defaults/` if nothing remains
+7. Report: "Migrated framework files from .documentation/ → .devspark/"
+
+### Migration: Root-level directories (legacy layout)
+
+1. Copy `memory/*` → `.documentation/memory/` (skip existing)
+2. Copy `specs/*` → `.documentation/specs/` (skip existing)
+3. Rename migrated directories → `{name}.old/` (e.g., `memory.old/`)
+
+### Migration: Old Codex shims
+
+1. Rename `.codex/prompts/specify.*.md` → `.codex/prompts/devspark.*.md`
+2. In all shim files, replace `.documentation/defaults/commands/` → `.devspark/defaults/commands/`
+3. Check other agent directories too (`.github/agents/`, `.claude/commands/`, `.cursor/commands/`) — rename `specify.*` → `devspark.*` if found
+
+After migration, continue with Step 3.
+
+### Constitution bootstrap questions (only if needed)
+
+After detection and any migration work above, check whether `.documentation/memory/constitution.md` already exists.
+
+- If it exists already, or was migrated into place, **do not** ask for project name, tech stack, or core principles.
+- If it does not exist, ask these additional questions before Step 3:
+  1. **Project name** — What is this project called?
+  2. **Tech stack** — What languages, frameworks, and tools does this project use?
+  3. **Core principles** — Name 3–5 non-negotiable principles for this project (e.g., "test-first", "accessibility", "API-first", "simplicity"). If unsure, say "use defaults" and you'll get a starter set.
+
+### If `.devspark/` already exists — Version Check
+
+1. Read `.devspark/VERSION`. If the file is missing or `version:` is not semver (`X.Y.Z`), treat the installed version as `unknown`.
+2. Fetch `https://raw.githubusercontent.com/markhazleton/devspark/main/CHANGELOG.md` and extract the most recent `## [X.Y.Z]` heading as `LATEST_VERSION`.
+3. Compare and act:
+
+| Installed version | Latest version | Action |
+|---|---|---|
+| Same as latest | — | Verify framework files. If any stock prompt, template, script, or Codex shim is missing, run **repair mode** below. Otherwise report: "DevSpark is already at vX.Y.Z — nothing to update." Skip to Step 11 (Verify & Report). |
+| Older than latest | Newer | Report the version gap, then run **update mode** below. |
+| `unknown` (VERSION missing) | Any | Treat as outdated. Run **update mode**. |
+
+#### Update Mode
+
+Tell the user: "Updating DevSpark from vX.Y.Z → vY.Y.Y. Your `.documentation/` files will not be touched."
+
+Execute **only** these steps in order, then skip to Step 11 (Verify & Report):
+
+- **Step 4** — Re-fetch all stock prompts into `.devspark/defaults/commands/` (overwrite)
+- **Step 5** — Re-fetch all helper templates into `.devspark/templates/` (overwrite)
+- **Step 6** — Re-fetch all scripts into `.devspark/scripts/` (overwrite)
+- **Step 7** — Re-create all Codex prompt shim files (overwrite — shims are framework files)
+- **Step 9** — Update `.devspark/VERSION` with new version and today's date
+
+**Never touch** `.documentation/`, the constitution, `.gitignore`, or any platform guide files.
+
+#### Repair Mode
+
+If the installed version matches `LATEST_VERSION` but framework files are missing, tell the user: "DevSpark is already at vX.Y.Z, but the framework install is incomplete. Re-fetching stock files to repair it. Your `.documentation/` files will not be touched."
+
+Execute **only** these steps in order, then skip to Step 11 (Verify & Report):
+
+- **Step 4** — Re-fetch all stock prompts into `.devspark/defaults/commands/` (overwrite missing or stale copies)
+- **Step 5** — Re-fetch all helper templates into `.devspark/templates/` (overwrite missing or stale copies)
+- **Step 6** — Re-fetch all scripts into `.devspark/scripts/` (overwrite missing or stale copies)
+- **Step 7** — Re-create all Codex prompt shim files (overwrite missing or stale copies)
+- **Step 9** — Re-write `.devspark/VERSION` using the current `LATEST_VERSION` and today's date
+
+---
+
+## Step 3: Create Directory Structure
+
+Create these directories (skip any that already exist):
+
+```text
+.devspark/
+├── defaults/commands/
+├── scripts/
+└── templates/
+
+.documentation/
+├── memory/
+├── specs/
+├── commands/          ← team-level overrides (optional)
+└── decisions/
+
+.codex/
+└── prompts/
+```
+
+---
+
+## Step 4: Pull Stock Prompts
+
+Fetch each file from `https://raw.githubusercontent.com/markhazleton/devspark/main/templates/commands/` and save to `.devspark/defaults/commands/` with the `devspark.` prefix:
+
+| Source file | Destination |
+|---|---|
+| `specify.md` | `.devspark/defaults/commands/devspark.specify.md` |
+| `plan.md` | `.devspark/defaults/commands/devspark.plan.md` |
+| `tasks.md` | `.devspark/defaults/commands/devspark.tasks.md` |
+| `implement.md` | `.devspark/defaults/commands/devspark.implement.md` |
+| `create-pr.md` | `.devspark/defaults/commands/devspark.create-pr.md` |
+| `constitution.md` | `.devspark/defaults/commands/devspark.constitution.md` |
+| `pr-review.md` | `.devspark/defaults/commands/devspark.pr-review.md` |
+| `address-pr-review.md` | `.devspark/defaults/commands/devspark.address-pr-review.md` |
+| `quickfix.md` | `.devspark/defaults/commands/devspark.quickfix.md` |
+| `harvest.md` | `.devspark/defaults/commands/devspark.harvest.md` |
+| `release.md` | `.devspark/defaults/commands/devspark.release.md` |
+| `critic.md` | `.devspark/defaults/commands/devspark.critic.md` |
+| `clarify.md` | `.devspark/defaults/commands/devspark.clarify.md` |
+| `analyze.md` | `.devspark/defaults/commands/devspark.analyze.md` |
+| `checklist.md` | `.devspark/defaults/commands/devspark.checklist.md` |
+| `personalize.md` | `.devspark/defaults/commands/devspark.personalize.md` |
+| `site-audit.md` | `.devspark/defaults/commands/devspark.site-audit.md` |
+| `evolve-constitution.md` | `.devspark/defaults/commands/devspark.evolve-constitution.md` |
+| `discover-constitution.md` | `.devspark/defaults/commands/devspark.discover-constitution.md` |
+| `repo-story.md` | `.devspark/defaults/commands/devspark.repo-story.md` |
+| `archive.md` | `.devspark/defaults/commands/devspark.archive.md` (deprecated compatibility alias for harvest) |
+| `upgrade.md` | `.devspark/defaults/commands/devspark.upgrade.md` |
+| `update-pr.md` | `.devspark/defaults/commands/devspark.update-pr.md` |
+| `taskstoissues.md` | `.devspark/defaults/commands/devspark.taskstoissues.md` |
+| `add-application.md` | `.devspark/defaults/commands/devspark.add-application.md` |
+| `list-applications.md` | `.devspark/defaults/commands/devspark.list-applications.md` |
+| `validate-registry.md` | `.devspark/defaults/commands/devspark.validate-registry.md` |
+
+---
+
+## Step 5: Pull Helper Templates
+
+Fetch from `https://raw.githubusercontent.com/markhazleton/devspark/main/templates/` and save to `.devspark/templates/`:
+
+- `spec-template.md`
+- `plan-template.md`
+- `tasks-template.md`
+- `quick-spec-template.md`
+- `checklist-template.md`
+- `agent-file-template.md`
+
+Also fetch `https://raw.githubusercontent.com/markhazleton/devspark/main/agents-registry.json` and save it to `agents-registry.json` at the repository root.
+
+---
+
+## Step 6: Pull Scripts
+
+Fetch scripts from `https://raw.githubusercontent.com/markhazleton/devspark/main/scripts/` based on the user's script preference from Step 1.
+
+For **PowerShell** (`ps`), save to `.devspark/scripts/powershell/`:
+
+- `powershell/common.ps1`
+- `powershell/platform.ps1`
+- `powershell/check-prerequisites.ps1`
+- `powershell/create-new-feature.ps1`
+- `powershell/setup-plan.ps1`
+- `powershell/get-pr-context.ps1`
+- `powershell/address-pr-review.ps1`
+- `powershell/create-pr.ps1`
+- `powershell/update-agent-context.ps1`
+- `powershell/archive-context.ps1` (deprecated compatibility wrapper around harvest)
+- `powershell/evolution-context.ps1`
+- `powershell/harvest.ps1`
+- `powershell/quickfix-context.ps1`
+- `powershell/release-context.ps1`
+- `powershell/repo-story-context.ps1`
+- `powershell/site-audit.ps1`
+
+For **Bash** (`sh`), save to `.devspark/scripts/bash/`:
+
+- `bash/common.sh`
+- `bash/platform.sh`
+- `bash/check-prerequisites.sh`
+- `bash/create-new-feature.sh`
+- `bash/setup-plan.sh`
+- `bash/get-pr-context.sh`
+- `bash/create-pr.sh`
+- `bash/update-agent-context.sh`
+- `bash/archive-context.sh` (deprecated compatibility wrapper around harvest)
+- `bash/evolution-context.sh`
+- `bash/harvest.sh`
+- `bash/quickfix-context.sh`
+- `bash/release-context.sh`
+- `bash/repo-story-context.sh`
+- `bash/site-audit.sh`
+
+**Script override layer:** If the team later needs to customize a script (e.g., for Azure DevOps instead of GitHub), they copy the script to `.documentation/scripts/{bash|powershell}/` and edit it there. The team copy takes priority over the stock version in `.devspark/scripts/`. Upgrades only overwrite `.devspark/scripts/` and never touch `.documentation/scripts/`.
+
+`/devspark.specify` is the canonical intake command after bootstrap. It recommends a one-off fix, quick spec, or full spec route and asks the user to confirm before proceeding.
+
+---
+
+## Step 7: Create Codex Prompt Shims and AGENTS.md
+
+For each command in `.devspark/defaults/commands/devspark.{name}.md`, create a shim file in `.codex/prompts/`.
+
+Create `.codex/prompts/devspark.{name}.md`:
+
+```markdown
+---
+description: DevSpark {name} command shim.
+---
+
+## Prompt Resolution
+
+Determine the current git user by running `git config user.name`.
+Normalize to a folder-safe slug: lowercase, replace spaces with hyphens, strip non-alphanumeric/hyphen chars.
+
+Read and execute the instructions from the **first file that exists**:
+1. `.documentation/{git-user}/commands/devspark.{name}.md` (personalized override)
+2. `.documentation/commands/devspark.{name}.md` (team customization)
+3. `.devspark/defaults/commands/devspark.{name}.md` (stock default)
+
+## User Input
+
+$ARGUMENTS
+
+Pass the user input above to the resolved prompt.
+```
+
+Replace `{name}` in every file with the actual command name.
+
+Then create or update root `AGENTS.md` if it does not already exist. Keep it concise so Codex can load it reliably:
+
+```markdown
+# AGENTS.md
+
+## DevSpark
+
+- DevSpark framework files live in `.devspark/`.
+- Project artifacts and team overrides live in `.documentation/`.
+- Resolve DevSpark commands through the first existing file:
+  1. `.documentation/{git-user}/commands/devspark.{name}.md`
+  2. `.documentation/commands/devspark.{name}.md`
+  3. `.devspark/defaults/commands/devspark.{name}.md`
+- Preserve user work in `.documentation/`; upgrades refresh `.devspark/` only.
+```
+
+If `AGENTS.md` already exists, do not overwrite it. Add the DevSpark section only if it is clearly missing, preserving existing instructions.
+
+---
+
+## Step 8: Seed the Constitution
+
+If `.documentation/memory/constitution.md` does not already exist, fetch `https://raw.githubusercontent.com/markhazleton/devspark/main/.documentation/memory/constitution.md` and save it there.
+
+If the file was migrated from `.specify/` or already existed, preserve it and do not overwrite it.
+
+Only when creating a new constitution, use the project name, tech stack, and core principles collected after Step 2 to customize `.documentation/memory/constitution.md`:
+
+- Replace `[PROJECT_NAME]` with the actual project name
+- Fill in the core principles the user provided
+- Add the tech stack as a "Technology" or "Stack" section
+
+---
+
+## Step 9: Write VERSION Stamp
+
+Use the `LATEST_VERSION` you already fetched in Step 2.
+
+Create `.devspark/VERSION`:
+
+```text
+version: {LATEST_VERSION}
+installed: {today's date YYYY-MM-DD}
+method: codex-quickstart
+migrated-from: {legacy-layout | documentation-defaults | fresh}
+```
+
+---
+
+## Step 10: Update .gitignore
+
+Append to `.gitignore` if not already present:
+
+```text
+# DevSpark — personal overrides (never commit)
+.documentation/*/commands/
+```
+
+---
+
+## Step 11: Verify & Report
+
+Confirm the installation:
+
+- Check that every stock prompt from Step 4 exists in `.devspark/defaults/commands/`
+- Check that every helper template from Step 5 exists in `.devspark/templates/`
+- Check that the selected script set from Step 6 exists under `.devspark/scripts/`
+- Check that the expected Codex shim files from Step 7 exist in `.codex/prompts/`
+- Check that root `AGENTS.md` exists or that an existing one was preserved with DevSpark guidance added
+- If any expected framework file is missing, stop and run **Repair Mode** before reporting success
+
+- **Migration summary**: What was migrated and where backups live (`.specify.old/`, etc.)
+- Number of stock commands in `.devspark/defaults/commands/`
+- Number of Codex prompt shims created in `.codex/prompts/`
+- Constitution status: seeded fresh, migrated, or already existed
+- `AGENTS.md` status: created, updated, or already existed
+- Repair status: not needed, or repaired missing framework files
+- Explain the 3-tier override system and that the personalize command creates per-user overrides
+- If backup directories exist, remind the user they can delete them once satisfied
+
+Tell the user: type `/devspark.specify` in Codex to start using DevSpark.
+
+If `/devspark.specify` does not appear in Codex CLI, give session-scoped prompt-discovery guidance.
+
+PowerShell:
+
+```powershell
+$env:CODEX_HOME = (Resolve-Path .codex).Path
+codex
+```
+
+Bash:
+
+```bash
+export CODEX_HOME="$(pwd)/.codex"
+codex
+```
+
+Do not use `setx` or otherwise persist `CODEX_HOME` unless the user explicitly asks.
+
+Add maintenance guidance (prompt-first):
+
+- Basic (recommended): run the remote upgrade prompt URL in chat
+- `https://raw.githubusercontent.com/markhazleton/devspark/main/templates/commands/upgrade.md`
+- Advanced (optional): if CLI is installed, run `devspark upgrade`
+
+For either path, upgrades refresh `.devspark/` stock files while preserving `.documentation/` team and personal customizations.
+
+---
+
+## Multi-App Monorepo Support (Optional)
+
+> **This section is entirely optional.** If your repository contains a single application, skip this section — DevSpark works perfectly without it.
+
+For repositories containing **multiple applications** with different platforms, runtimes, or governance rules, DevSpark offers opt-in multi-app support.
+
+### When to Consider Multi-App
+
+- Your monorepo has apps with different tech stacks (e.g., .NET API + React UI)
+- Different apps need different governance rules or risk profiles
+- You want per-app constitutions, profiles, or code review scopes
+
+### Quick Setup
+
+1. Run `/devspark.add-application` to create a registry at `.documentation/devspark.json` interactively
+2. Each application gets its own `.documentation/` directory at `{app-path}/.documentation/`
+3. Use `--app <id>` with any DevSpark command to scope it to a specific application
+4. Use `--repo-scope` for repository-wide operations
+
+### Key Concepts
+
+- **Registry**: `.documentation/devspark.json` defines all applications, profiles, and dependencies
+- **Profiles**: Reusable rule bundles (e.g., `api-profile`, `web-profile`) that apps inherit
+- **App-local manifest**: Optional `{app-path}/app.json` for app-specific overrides
+- **Scope**: Every workflow runs in `repo`, `single-app`, or `cross-app` scope
+
+### Commands
+
+| Command | Purpose |
+|---------|--------|
+| `/devspark.add-application` | Register a new application in the registry |
+| `/devspark.list-applications` | View all registered applications and profiles |
+| `/devspark.validate-registry` | Validate registry schema, references, and consistency |
+
+For details, see the [Multi-App Specification](https://github.com/markhazleton/devspark/blob/main/.documentation/specs/001-multi-app-monorepo-support/spec.md).

--- a/quickstart/devspark_quickstart_copilot.md
+++ b/quickstart/devspark_quickstart_copilot.md
@@ -90,7 +90,7 @@ Choose the banner that matches the detected state from Step 2:
 
 Output the banner, then immediately output a brief **plan preview** — one line per action group:
 
-```
+```text
 Plan:
   • Create directories: .devspark/, .documentation/, .github/, .vscode/
   • Fetch N stock prompts → .devspark/defaults/commands/
@@ -464,7 +464,7 @@ If **any** check fails, run Repair Mode before reporting success. Do not tell th
 
 Output the following summary (adapt counts and status to what actually ran):
 
-```
+```text
 ✔ DevSpark {LATEST_VERSION} — {MODE} complete
 
 Mode:          {FRESH INSTALL | UPDATE vX.Y.Z → vY.Y.Y | REPAIR | MIGRATION → FRESH INSTALL}
@@ -495,7 +495,7 @@ Constitution: {seeded fresh | migrated from .specify/ | already existed — not 
 
 Tell the user:
 
-```
+```text
 Start DevSpark: type @devspark.specify in Copilot Chat.
 
 Recommended entrypoints (DevSpark v2):

--- a/src/devspark_cli/_app.py
+++ b/src/devspark_cli/_app.py
@@ -8,6 +8,7 @@ from rich.console import Console
 from rich.text import Text
 from typer.core import TyperGroup
 
+from .commands.skills import skills_app
 from .harness.cli import adapter_app, harness_app
 
 BANNER = """
@@ -43,6 +44,7 @@ app = typer.Typer(
 
 app.add_typer(harness_app, name="harness")
 app.add_typer(adapter_app, name="adapter")
+app.add_typer(skills_app, name="skills")
 
 
 def show_banner():

--- a/src/devspark_cli/_template.py
+++ b/src/devspark_cli/_template.py
@@ -17,6 +17,7 @@ from rich.progress import Progress, SpinnerColumn, TextColumn
 from ._app import console
 from ._github import _format_rate_limit_error, _github_auth_headers, ssl_context
 from ._utils import StepTracker
+from .agent_registry import AGENT_CONFIG
 
 # Paths that are never overwritten when the destination file already exists.
 # Everything under .documentation/ is user-owned work product.
@@ -241,6 +242,14 @@ def download_template_from_github(ai_assistant: str, download_dir: Path, *, scri
                     "",
                     "GitHub Copilot quickstart (prompt-first):",
                     "[cyan]https://raw.githubusercontent.com/markhazleton/devspark/main/quickstart/devspark_quickstart_copilot.md[/cyan]",
+                ]
+            )
+        elif ai_assistant == "codex":
+            guidance_lines.extend(
+                [
+                    "",
+                    "Codex quickstart (prompt-first):",
+                    "[cyan]https://raw.githubusercontent.com/markhazleton/devspark/main/quickstart/devspark_quickstart_codex.md[/cyan]",
                 ]
             )
         console.print(Panel("\n".join(guidance_lines), title="Recovery Guidance", border_style="cyan"))
@@ -554,12 +563,12 @@ def _seed_user_artifacts(project_path: Path) -> None:
     memory_dir.mkdir(parents=True, exist_ok=True)
 
 
-def validate_installation_manifest(project_path: Path) -> dict:
+def validate_installation_manifest(project_path: Path, ai_assistant: str | None = None) -> dict:
     """Cross-check installed commands against generated agent shims.
 
     Scans ``.devspark/defaults/commands/devspark.*.md`` as the source of truth
-    for which commands are installed, then verifies a matching
-    ``.github/agents/devspark.*.agent.md`` exists for each.
+    for which commands are installed, then verifies a matching agent shim exists
+    in the selected agent's registered command directory.
 
     Returns a dict with:
         command_count   – number of installed stock command files
@@ -569,7 +578,10 @@ def validate_installation_manifest(project_path: Path) -> dict:
         valid           – True when missing_shims is empty
     """
     commands_dir = project_path / ".devspark" / "defaults" / "commands"
-    agents_dir = project_path / ".github" / "agents"
+    agent_key = ai_assistant or "copilot"
+    release = AGENT_CONFIG.get(agent_key, {}).get("release", {})
+    shim_dir = project_path / release.get("commands_dir", ".github/agents")
+    extension = release.get("extension", "agent.md")
 
     installed_commands: list[str] = []
     if commands_dir.is_dir():
@@ -579,11 +591,12 @@ def validate_installation_manifest(project_path: Path) -> dict:
                 installed_commands.append(name[len("devspark."):])
 
     present_shims: list[str] = []
-    if agents_dir.is_dir():
-        for p in sorted(agents_dir.glob("devspark.*.agent.md")):
-            stem = p.name  # e.g. "devspark.specify.agent.md"
-            if stem.startswith("devspark.") and stem.endswith(".agent.md"):
-                present_shims.append(stem[len("devspark."):-len(".agent.md")])
+    if shim_dir.is_dir():
+        suffix = f".{extension}"
+        for p in sorted(shim_dir.glob(f"devspark.*{suffix}")):
+            stem = p.name
+            if stem.startswith("devspark.") and stem.endswith(suffix):
+                present_shims.append(stem[len("devspark."):-len(suffix)])
 
     missing_shims = [cmd for cmd in installed_commands if cmd not in present_shims]
     extra_shims = [shim for shim in present_shims if shim not in installed_commands]
@@ -591,6 +604,9 @@ def validate_installation_manifest(project_path: Path) -> dict:
     return {
         "installed_commands": installed_commands,
         "command_count": len(installed_commands),
+        "agent": agent_key,
+        "shim_dir": str(shim_dir),
+        "shim_extension": extension,
         "present_shims": present_shims,
         "shim_count": len(present_shims),
         "missing_shims": missing_shims,

--- a/src/devspark_cli/commands/init.py
+++ b/src/devspark_cli/commands/init.py
@@ -247,7 +247,7 @@ def init(
 
             tracker.start("shim-validate")
             repaired_count = repair_agent_shim_frontmatter(project_path)
-            manifest = validate_installation_manifest(project_path)
+            manifest = validate_installation_manifest(project_path, selected_ai)
             repair_detail = f"repaired {repaired_count}, " if repaired_count else ""
             manifest_detail = f"{manifest['command_count']} commands / {manifest['shim_count']} shims"
             if manifest["missing_shims"]:
@@ -360,11 +360,12 @@ def init(
         codex_path = project_path / ".codex"
         quoted_path = shlex.quote(str(codex_path))
         if os.name == "nt":  # Windows
-            cmd = f"setx CODEX_HOME {quoted_path}"
+            ps_path = str(codex_path).replace("'", "''")
+            cmd = f"$env:CODEX_HOME = '{ps_path}'"
         else:  # Unix-like systems
             cmd = f"export CODEX_HOME={quoted_path}"
 
-        steps_lines.append(f"{step_num}. Set [cyan]CODEX_HOME[/cyan] environment variable before running Codex: [cyan]{cmd}[/cyan]")
+        steps_lines.append(f"{step_num}. Optional for Codex custom prompt discovery in older CLI builds: [cyan]{cmd}[/cyan]")
         step_num += 1
 
     steps_lines.append(f"{step_num}. Start using slash commands with your AI agent:")

--- a/src/devspark_cli/commands/skills.py
+++ b/src/devspark_cli/commands/skills.py
@@ -1,6 +1,6 @@
 """Skills subcommand group: list and validate DevSpark Agent Skills."""
+import os
 import re
-import sys
 from pathlib import Path
 
 import typer
@@ -41,12 +41,27 @@ _BODY_FAIL_LINES = 500
 
 
 def _find_skills_root() -> Path:
-    """Locate the templates/skills/ directory relative to the package."""
+    """Locate the templates/skills/ directory.
+
+    Resolution order:
+    1. DEVSPARK_SKILLS_ROOT env var — explicit override for installed/CI environments.
+    2. __file__-relative path — works in source-tree and editable installs only.
+       When installed as a wheel, templates/ is not part of the package and this
+       path will not exist; a warning is emitted so the user knows to set the env var.
+    """
+    env_override = os.environ.get("DEVSPARK_SKILLS_ROOT")
+    if env_override:
+        return Path(env_override)
+
     # Path(__file__) = src/devspark_cli/commands/skills.py
     # .parent = commands/, .parent = devspark_cli/, .parent = src/, .parent = repo root
-    package_dir = Path(__file__).parent.parent.parent
-    repo_root = package_dir.parent
-    return repo_root / "templates" / "skills"
+    computed = Path(__file__).parent.parent.parent.parent / "templates" / "skills"
+    if not computed.exists():
+        stderr_console.print(
+            f"[yellow]Warning[/yellow]: skills directory not found at {computed}. "
+            "Set DEVSPARK_SKILLS_ROOT to the templates/skills/ path for installed environments."
+        )
+    return computed
 
 
 def _parse_skill_md(skill_dir: Path):

--- a/src/devspark_cli/commands/skills.py
+++ b/src/devspark_cli/commands/skills.py
@@ -1,0 +1,277 @@
+"""Skills subcommand group: list and validate DevSpark Agent Skills."""
+import re
+import sys
+from pathlib import Path
+
+import typer
+import yaml
+from rich.console import Console
+from rich.table import Table
+
+skills_app = typer.Typer(name="skills", help="Manage and validate DevSpark Agent Skills.")
+
+console = Console()
+stderr_console = Console(stderr=True)
+
+# Rules from SKILL-validation-contract.md
+_NAME_REGEX = re.compile(r"^[a-z0-9]+(-[a-z0-9]+)*$")
+_VERSION_REGEX = re.compile(r"^\d+\.\d+\.\d+$")
+_PROHIBITED_KEYS = {
+    "handoffs",
+    "scripts",
+    "classification",
+    "required_gates",
+    "recommended_next_step",
+    "version",
+}
+_PROHIBITED_BODY_STRINGS = [
+    ".devspark/",
+    "{SCRIPT}",
+    "FEATURE_DIR",
+    "{AGENT_SCRIPT}",
+    "handoffs:",
+]
+_BODY_WARN_LINES = 400
+_BODY_FAIL_LINES = 500
+
+# Output format note: --json flag is intentionally omitted in this release.
+# The output format is not yet stable for scripting consumption.
+# Do not parse this output in scripts until a --json flag is added in a
+# future semver release and the format is declared stable.
+
+
+def _find_skills_root() -> Path:
+    """Locate the templates/skills/ directory relative to the package."""
+    # Path(__file__) = src/devspark_cli/commands/skills.py
+    # .parent = commands/, .parent = devspark_cli/, .parent = src/, .parent = repo root
+    package_dir = Path(__file__).parent.parent.parent
+    repo_root = package_dir.parent
+    return repo_root / "templates" / "skills"
+
+
+def _parse_skill_md(skill_dir: Path):
+    """Return (frontmatter_dict, body_lines) or (None, None) on parse failure."""
+    skill_file = skill_dir / "SKILL.md"
+    if not skill_file.exists():
+        return None, None
+    try:
+        content = skill_file.read_text(encoding="utf-8")
+    except OSError:
+        return None, None
+    if not content.startswith("---"):
+        return {}, content.splitlines()
+    parts = content.split("---", 2)
+    if len(parts) < 3:
+        return {}, content.splitlines()
+    try:
+        fm = yaml.safe_load(parts[1]) or {}
+    except yaml.YAMLError:
+        return {}, content.splitlines()
+    return fm, parts[2].splitlines()
+
+
+def _validate_skill(skill_dir: Path, skill_name: str):
+    """Validate one skill. Returns (status, findings).
+
+    status: 'pass', 'warn', or 'fail'
+    findings: list of (severity, rule, message) tuples
+    """
+    findings = []
+
+    fm, body_lines = _parse_skill_md(skill_dir)
+    if fm is None:
+        findings.append(("error", "skill-unreadable", "SKILL.md could not be read"))
+        return "fail", findings
+
+    # name
+    name = fm.get("name", "")
+    if not name:
+        findings.append(("error", "name-missing", "frontmatter must contain 'name' field"))
+    else:
+        if name != skill_name:
+            findings.append((
+                "error", "name-mismatch",
+                f'[name-mismatch] [{name}] name "{name}" does not match directory "{skill_name}"',
+            ))
+        if not _NAME_REGEX.match(name):
+            findings.append((
+                "error", "name-format",
+                f'[name-format] [{name}] name must match [a-z0-9]+(-[a-z0-9]+)* pattern',
+            ))
+        if len(name) > 64:
+            findings.append((
+                "error", "name-length",
+                f'[name-length] [{len(name)}] name length {len(name)} exceeds 64',
+            ))
+
+    # description
+    desc = str(fm.get("description", ""))
+    if not desc.strip():
+        findings.append(("error", "description-empty", "[description-empty] description must be non-empty"))
+    elif len(desc) > 1024:
+        findings.append((
+            "error", "description-length",
+            f'[description-length] [{len(desc)}] description length {len(desc)} exceeds 1024',
+        ))
+
+    # metadata.version
+    metadata = fm.get("metadata", {})
+    if not isinstance(metadata, dict) or "version" not in metadata:
+        findings.append(("error", "version-missing", "[version-missing] metadata.version is required"))
+    else:
+        version = metadata.get("version")
+        if not isinstance(version, str):
+            findings.append((
+                "error", "version-type",
+                f'[version-type] [{version!r}] metadata.version must be a quoted string; got {type(version).__name__}',
+            ))
+        else:
+            if not _VERSION_REGEX.match(version):
+                findings.append((
+                    "error", "version-format",
+                    f'[version-format] ["{version}"] metadata.version "{version}" does not match MAJOR.MINOR.PATCH',
+                ))
+
+    # prohibited keys
+    found_prohibited = _PROHIBITED_KEYS & set(fm.keys())
+    for key in sorted(found_prohibited):
+        findings.append((
+            "error", "prohibited-key",
+            f'[prohibited-key] [{key}] frontmatter key "{key}" is not permitted in SKILL.md',
+        ))
+
+    # body rules
+    if body_lines is not None:
+        body = "\n".join(body_lines)
+        count = len(body_lines)
+        if count > _BODY_FAIL_LINES:
+            findings.append((
+                "error", "body-length",
+                f'[body-length] [{count}] body line count {count} exceeds maximum of {_BODY_FAIL_LINES}',
+            ))
+        elif count > _BODY_WARN_LINES:
+            findings.append((
+                "warning", "body-budget",
+                f'[body-budget] [{count}] body line count {count} exceeds advisory limit of {_BODY_WARN_LINES}; consider moving content to references/',
+            ))
+
+        for bad_string in _PROHIBITED_BODY_STRINGS:
+            if bad_string in body:
+                findings.append((
+                    "error", "body-scan",
+                    f'[body-scan] [{bad_string}] body contains DevSpark-specific string "{bad_string}"',
+                ))
+
+    errors = [f for f in findings if f[0] == "error"]
+    warnings = [f for f in findings if f[0] == "warning"]
+
+    if errors:
+        return "fail", findings
+    if warnings:
+        return "warn", findings
+    return "pass", findings
+
+
+@skills_app.command("list")
+def list_skills():
+    """List all Agent Skills found under templates/skills/."""
+    skills_root = _find_skills_root()
+    if not skills_root.exists():
+        console.print(f"[yellow]No skills directory found at {skills_root}[/yellow]")
+        raise typer.Exit(0)
+
+    skill_dirs = sorted(
+        [d for d in skills_root.iterdir() if d.is_dir() and (d / "SKILL.md").exists()]
+    )
+
+    if not skill_dirs:
+        console.print("[yellow]No skills found.[/yellow]")
+        raise typer.Exit(0)
+
+    table = Table(title="DevSpark Agent Skills", show_lines=True)
+    table.add_column("Name", style="bold cyan")
+    table.add_column("Version", style="green")
+    table.add_column("Path", style="dim")
+    table.add_column("Status")
+
+    for skill_dir in skill_dirs:
+        skill_name = skill_dir.name
+        fm, _ = _parse_skill_md(skill_dir)
+        if fm is None:
+            table.add_row(skill_name, "-", str(skill_dir), "[red]unreadable[/red]")
+            continue
+        version = str((fm.get("metadata") or {}).get("version", "-"))
+        status, findings = _validate_skill(skill_dir, skill_name)
+        status_display = (
+            "[green]pass[/green]" if status == "pass"
+            else "[yellow]warn[/yellow]" if status == "warn"
+            else "[red]fail[/red]"
+        )
+        table.add_row(skill_name, version, str(skill_dir.relative_to(skill_dir.parent.parent)), status_display)
+
+    console.print(table)
+
+
+@skills_app.command("validate")
+def validate_skills(
+    path: str = typer.Argument(None, help="Path to a single skill directory to validate, or omit to validate all skills."),
+):
+    """Validate Agent Skills against the SKILL validation contract.
+
+    Exits 0 on pass or warn; exits 1 on any failure.
+    Warn diagnostics go to stderr; fail diagnostics go to stderr.
+    """
+    skills_root = _find_skills_root()
+
+    if path:
+        skill_path = Path(path)
+        if not skill_path.is_absolute():
+            skill_path = Path.cwd() / skill_path
+        skill_dirs = [(skill_path, skill_path.name)] if skill_path.exists() else []
+        if not skill_dirs:
+            stderr_console.print(f"[red]Skill path not found: {skill_path}[/red]")
+            raise typer.Exit(1)
+    else:
+        if not skills_root.exists():
+            stderr_console.print(f"[red]No skills directory found at {skills_root}[/red]")
+            raise typer.Exit(1)
+        skill_dirs = [
+            (d, d.name)
+            for d in sorted(skills_root.iterdir())
+            if d.is_dir() and (d / "SKILL.md").exists()
+        ]
+
+    if not skill_dirs:
+        console.print("[yellow]No skills found to validate.[/yellow]")
+        raise typer.Exit(0)
+
+    any_fail = False
+    warn_count = 0
+
+    for skill_dir, skill_name in skill_dirs:
+        status, findings = _validate_skill(skill_dir, skill_name)
+        fm, _ = _parse_skill_md(skill_dir)
+        version = str((fm or {}).get("metadata", {}).get("version", "-")) if fm else "-"
+
+        if status == "pass":
+            console.print(f"[green]PASS[/green] {skill_name} {version}")
+        elif status == "warn":
+            warnings = [f for f in findings if f[0] == "warning"]
+            warn_count += len(warnings)
+            console.print(f"[yellow]WARN[/yellow] {skill_name} {version}")
+            for _, _, msg in warnings:
+                stderr_console.print(f"  [yellow]warn[/yellow]: {msg}")
+        else:
+            any_fail = True
+            console.print(f"[red]FAIL[/red] {skill_name} {version}")
+            errors = [f for f in findings if f[0] == "error"]
+            for _, _, msg in errors:
+                stderr_console.print(f"  [red]fail[/red]: {msg}")
+
+    if warn_count > 0:
+        stderr_console.print(f"\n{warn_count} warning(s). Run with a specific path for details.")
+
+    if any_fail:
+        raise typer.Exit(1)
+
+    raise typer.Exit(0)

--- a/src/devspark_cli/harness/_probe_dispatch.py
+++ b/src/devspark_cli/harness/_probe_dispatch.py
@@ -322,32 +322,19 @@ def execute_step(
             if step.type != "validation":
                 adapter = get_adapter(adapter_name)
                 if hands_off and adapter_name == "manual":
+                    profile = probe_adapter(adapter_name)
+                    details = profile.remediation_guidance or "Select a non-interactive adapter for hands-off mode."
+                    message = (
+                        f"write_incompatible_adapter: step={step.id} adapter={adapter_name} "
+                        f"state={profile.state}. {details}"
+                    )
                     telemetry.emit(
                         "harness.policy.blocked",
                         context.run_id,
                         step_id=step.id,
-                        reason="hands_off_manual_gate_bypassed",
+                        reason=message,
                     )
-                    duration_ms = int((time.perf_counter() - attempt_started) * 1000)
-                    total_duration += duration_ms
-                    telemetry.emit(
-                        "harness.step.finished",
-                        context.run_id,
-                        step_id=step.id,
-                        attempt=attempt,
-                        status="passed",
-                        duration_ms=duration_ms,
-                    )
-                    result = StepResult(
-                        step_id=step.id,
-                        status="passed",
-                        attempts=attempt,
-                        adapter=adapter_name,
-                        duration_ms=total_duration,
-                        validation_findings=[],
-                        artifacts=compute_artifacts(step, before_snapshot, telemetry, context),
-                    )
-                    return result, next_step_index(step, step_lookup, success=True)
+                    raise RuntimeError(message)
                 enforce_write_capability(step, adapter_name, hands_off)
                 available, reason = adapter.is_available()
                 if not available:

--- a/src/devspark_cli/harness/adapters/__init__.py
+++ b/src/devspark_cli/harness/adapters/__init__.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from .base import AgentAdapter, ProbeResult
 from .claude_code import ClaudeCodeAdapter
+from .codex import CodexAdapter
 from .copilot import CopilotAdapter
 from .cursor import CursorAdapter
 from .manual import ManualAdapter
@@ -18,6 +19,7 @@ def get_registered_adapters() -> dict[str, AgentAdapter]:
 		"noop": NoopAdapter(),
 		"manual": ManualAdapter(),
 		"claude_code": ClaudeCodeAdapter(),
+		"codex": CodexAdapter(),
 		"copilot": CopilotAdapter(),
 		"cursor": CursorAdapter(),
 	}

--- a/src/devspark_cli/harness/adapters/codex.py
+++ b/src/devspark_cli/harness/adapters/codex.py
@@ -1,0 +1,14 @@
+"""OpenAI Codex CLI harness adapter."""
+
+from __future__ import annotations
+
+from .base import CommandLineAdapter
+
+
+class CodexAdapter(CommandLineAdapter):
+    name = "codex"
+    description = "OpenAI Codex CLI"
+    executable = "codex"
+
+    def build_command(self) -> list[str]:
+        return [self.executable, "exec", "--sandbox", "workspace-write", "-"]

--- a/templates/commands/analyze.md
+++ b/templates/commands/analyze.md
@@ -116,7 +116,7 @@ Focus on high-signal findings. Limit to 50 findings total; aggregate remainder i
 
 - Flag vague adjectives (fast, scalable, secure, intuitive, robust) lacking measurable criteria
 - Flag unresolved placeholders (TODO, TKTK, ???, `<placeholder>`, etc.)
-- **Scope**: this pass evaluates whether the requirement is _worded precisely enough to act on_. Whether the stated target is _achievable in production_ is `/devspark.critic`'s responsibility — do not duplicate.
+- **Scope**: this pass evaluates whether the requirement is *worded precisely enough to act on*. Whether the stated target is *achievable in production* is `/devspark.critic`'s responsibility — do not duplicate.
 
 #### C. Underspecification
 
@@ -134,7 +134,7 @@ Focus on high-signal findings. Limit to 50 findings total; aggregate remainder i
 - Requirements with zero associated tasks
 - Tasks with no mapped requirement/story
 - Non-functional requirements not reflected in tasks (e.g., performance, security)
-- **Scope**: this pass only checks whether _stated_ requirements have _stated_ tasks. Whether the spec is _missing_ operational tasks (observability, rollback, backups, runbooks) that no requirement called for is `/devspark.critic`'s responsibility.
+- **Scope**: this pass only checks whether *stated* requirements have *stated* tasks. Whether the spec is *missing* operational tasks (observability, rollback, backups, runbooks) that no requirement called for is `/devspark.critic`'s responsibility.
 
 #### F. Inconsistency
 

--- a/templates/commands/clarify.md
+++ b/templates/commands/clarify.md
@@ -22,7 +22,7 @@ You **MUST** consider the user input before proceeding (if not empty).
 **Step 2 of 4** in the authoring chain (`specify → clarify → plan → tasks`).
 
 - **Owns**: targeted ambiguity reduction in an existing spec via up to 5 interactive questions, each integrated into the appropriate spec section.
-- **Does NOT own**: drafting/replacing the spec (→ `/devspark.specify`); deciding stack/architecture/data-store choices (→ `/devspark.plan` — only ask here if the _absence_ of the choice blocks functional clarity); generating tasks (→ `/devspark.tasks`); adversarial review (→ `/devspark.critic`, `/devspark.analyze`).
+- **Does NOT own**: drafting/replacing the spec (→ `/devspark.specify`); deciding stack/architecture/data-store choices (→ `/devspark.plan` — only ask here if the *absence* of the choice blocks functional clarity); generating tasks (→ `/devspark.tasks`); adversarial review (→ `/devspark.critic`, `/devspark.analyze`).
 - **Seed queue**: any `[NEEDS CLARIFICATION: …]` markers left by `/devspark.specify` are the first candidates; resolving them removes the marker in addition to the standard integration.
 
 ## Constitution Authority
@@ -138,6 +138,7 @@ Execution steps:
      | B      | <Option B description>                                                                              |
      | C      | <Option C description> (add D/E as needed up to 5)                                                  |
      | Short  | Provide a different short answer (<=5 words) (Include only if free-form alternative is appropriate) |
+
      - After the table, add: `You can reply with the option letter (e.g., "A"), accept the recommendation by saying "yes" or "recommended", or provide your own short answer.`
 
    - For short‑answer style (no meaningful discrete options):

--- a/templates/commands/constitution.md
+++ b/templates/commands/constitution.md
@@ -25,7 +25,7 @@ You **MUST** consider the user input before proceeding (if not empty).
 All three paths converge here → this command writes `constitution.md` and bumps the version.
 
 - **Owns**: collecting placeholder values, semver decisions, writing the constitution file, propagating impact to dependent templates, emitting the Sync Impact Report.
-- **Does NOT own**: reverse-engineering principles (→ `/devspark.discover-constitution`); generating amendment proposals (→ `/devspark.evolve-constitution`); reviewing/voting on proposals (out-of-band; this command only _applies_ approved ones).
+- **Does NOT own**: reverse-engineering principles (→ `/devspark.discover-constitution`); generating amendment proposals (→ `/devspark.evolve-constitution`); reviewing/voting on proposals (out-of-band; this command only *applies* approved ones).
 
 ## Upstream Inputs to Check
 

--- a/templates/commands/critic.md
+++ b/templates/commands/critic.md
@@ -37,7 +37,7 @@ These are deliberately **non-overlapping gates**. Critic does NOT re-check:
 
 - Internal artifact consistency, duplication, terminology drift → owned by `/devspark.analyze`
 - Whether stated requirements have matching tasks (req↔task coverage) → owned by `/devspark.analyze`
-- Whether requirement _wording_ is precise (vague adjectives, placeholders) → owned by `/devspark.analyze`
+- Whether requirement *wording* is precise (vague adjectives, placeholders) → owned by `/devspark.analyze`
 - **Rationale Summary completeness or spec↔plan Core-Problem drift** → owned by `/devspark.analyze`
 
 Critic DOES own: whether stated NFR targets are achievable, what operational/security/scale tasks are missing **regardless** of whether any requirement called for them, and archetype-specific production failure modes.
@@ -133,7 +133,7 @@ Read `change_type` from spec.md frontmatter. If missing, infer from file deltas 
 
 Read `risk_profile` from spec.md frontmatter; fall back to constitution; default to `internal`.
 
-**Severity scaling rule** (deterministic). Each finding has a _base severity_ from the category registry. Apply this shift to derive _effective severity_:
+**Severity scaling rule** (deterministic). Each finding has a *base severity* from the category registry. Apply this shift to derive *effective severity*:
 
 | Profile          | Shift                                                                  |
 | ---------------- | ---------------------------------------------------------------------- |
@@ -160,7 +160,7 @@ Extract failure-prone elements (skip sections whose artifact is absent):
 
 ### 6. Risk Category Registry (archetype-gated)
 
-Apply only categories whose `archetypes` set includes the detected archetype (or `*`). Each category has a _base severity ceiling_; the §4 profile shift adjusts findings up or down.
+Apply only categories whose `archetypes` set includes the detected archetype (or `*`). Each category has a *base severity ceiling*; the §4 profile shift adjusts findings up or down.
 
 | Category                    | Archetypes                                                               | Base ceiling |
 | --------------------------- | ------------------------------------------------------------------------ | ------------ |
@@ -226,7 +226,7 @@ Load all matching checklists from disk:
 - `.devspark/risk-checklists/{stack}.md` (e.g., `python-fastapi.md`, `node-express.md`, `go-gin.md`, `java-spring.md`, `dotnet-aspnet.md`)
 - `.devspark/risk-checklists/{archetype}.md` (e.g., `library.md`, `cli.md`, `data-pipeline.md`)
 
-If none exist, derive risks from first principles using the universal failure-mode lens above. Note in the report output: _"No stack/archetype checklists found at `.devspark/risk-checklists/` — consider seeding from prior critic runs."_ Stock seeds ship with DevSpark; teams override by placing files of the same name in `.documentation/risk-checklists/`.
+If none exist, derive risks from first principles using the universal failure-mode lens above. Note in the report output: *"No stack/archetype checklists found at `.devspark/risk-checklists/` — consider seeding from prior critic runs."* Stock seeds ship with DevSpark; teams override by placing files of the same name in `.documentation/risk-checklists/`.
 
 Every named tool in a checklist must be paired with the underlying capability so the model can translate across ecosystems. Pattern:
 
@@ -378,7 +378,7 @@ After producing the report:
 
 - Code style preferences (if linter configured)
 - Minor documentation-format inconsistencies
-- **Low-probability AND low-impact** issues _(low-probability/high-impact events must still be surfaced)_
+- **Low-probability AND low-impact** issues *(low-probability/high-impact events must still be surfaced)*
 - Micro-optimizations without proven bottlenecks
 
 ### Output Quality

--- a/templates/commands/discover-constitution.md
+++ b/templates/commands/discover-constitution.md
@@ -21,7 +21,7 @@ You **MUST** consider the user input before proceeding (if not empty). User may 
 
 **Brownfield bootstrap** step: `discover → constitution`, then later `evolve → constitution`.
 
-- **Owns**: scanning the codebase for implicit patterns, interactive validation, and producing a _draft_ at `/.documentation/memory/constitution-draft.md`.
+- **Owns**: scanning the codebase for implicit patterns, interactive validation, and producing a *draft* at `/.documentation/memory/constitution-draft.md`.
 - **Does NOT own**: writing or amending the real `constitution.md` (→ always `/devspark.constitution`); evidence-based amendment proposals once a constitution exists (→ `/devspark.evolve-constitution`).
 - **When NOT to use**: constitution already exists and is broadly accurate (→ `/devspark.evolve-constitution`); greenfield codebase (→ `/devspark.constitution` directly with aspirational principles).
 
@@ -82,7 +82,7 @@ Scan the codebase for patterns across these categories. For each, note:
 | ---------------------- | ------------------------------------------ |
 | Test framework         | Detect jest, vitest, mocha, pytest, etc.   |
 | Test file location     | Co-located vs. separate test directory     |
-| Test file naming       | _.test.ts, _.spec.ts, test\_\*.py patterns |
+| Test file naming       | `*.test.ts`, `*.spec.ts`, `test_*.py` patterns |
 | Coverage configuration | Presence of coverage config, thresholds    |
 | Test types present     | Unit, integration, e2e directories         |
 

--- a/templates/commands/evolve-constitution.md
+++ b/templates/commands/evolve-constitution.md
@@ -22,10 +22,10 @@ You **MUST** consider the user input before proceeding (if not empty).
 
 ## Lifecycle Position
 
-Continuous-improvement step: `PR reviews + audits → evolve-constitution → CAP-YYYY-NNN.md (DRAFT) → approve/reject → /devspark.constitution applies APPROVED CAPs`. Runs _after_ a constitution exists, _between_ version bumps.
+Continuous-improvement step: `PR reviews + audits → evolve-constitution → CAP-YYYY-NNN.md (DRAFT) → approve/reject → /devspark.constitution applies APPROVED CAPs`. Runs *after* a constitution exists, *between* version bumps.
 
 - **Owns**: pattern analysis across PR reviews and audits, gap detection, drafting Constitution Amendment Proposals (CAPs), and recording approve/reject decisions in `proposals/` and history.
-- **Does NOT own**: editing `constitution.md` (only `/devspark.constitution` writes it — this command always emits a _proposal_ file); bootstrapping (→ `/devspark.discover-constitution` brownfield, `/devspark.constitution` greenfield); performing the reviews themselves (→ `/devspark.pr-review`, `/devspark.site-audit`).
+- **Does NOT own**: editing `constitution.md` (only `/devspark.constitution` writes it — this command always emits a *proposal* file); bootstrapping (→ `/devspark.discover-constitution` brownfield, `/devspark.constitution` greenfield); performing the reviews themselves (→ `/devspark.pr-review`, `/devspark.site-audit`).
 - **Prerequisite**: if `/.documentation/memory/constitution.md` does not exist, halt and route to `/devspark.discover-constitution` (brownfield) or `/devspark.constitution` (greenfield). Never propose against a non-existent constitution.
 
 ## Overview

--- a/templates/commands/implement.md
+++ b/templates/commands/implement.md
@@ -178,7 +178,7 @@ Load `/.documentation/memory/constitution.md` at step 4. Treat every mandated pr
    **Continuous artifact sync** (required — do this as work happens, not at the end):
    - **tasks.md** — mark each task `[X]` immediately on completion. Never batch updates at the end of a phase. If a task is partially done, leave it `[ ]` and add a brief `<!-- WIP: ... -->` note rather than half-checking it.
    - **tasks.md phase checkpoints** — when every task in a phase (Setup, Foundational, User Story N, Polish) is `[X]`, append a checkpoint line under that phase heading: `**Checkpoint**: Phase complete — YYYY-MM-DD`. For user-story phases, this is the signal that the story is independently shippable.
-   - **spec.md user stories** — when all tasks tagged `[USn]` are `[X]`, update the corresponding `### User Story n` heading by appending ` ✅ Complete` (preserve the priority marker). This keeps the spec a live picture of delivered scope.
+   - **spec.md user stories** — when all tasks tagged `[USn]` are `[X]`, update the corresponding `### User Story n` heading by appending `✅ Complete` (preserve the priority marker). This keeps the spec a live picture of delivered scope.
    - **spec.md lifecycle status** — flip `**Status**: Draft` to `**Status**: In Progress` on the first completed task (already done in step 3); the final flip to `Complete` happens in step 11.
    - **plan.md** — if implementation discovers a deviation from the plan (different library chosen, contract adjusted, etc.), update plan.md inline and add a short `## Implementation Notes` entry dated and linked to the task ID. Do NOT silently diverge.
    - **Constitution waivers** — if a new waiver becomes necessary mid-implementation, **halt**, route the user to `/devspark.plan` to record it, then resume. Never invent waivers from within implement.
@@ -198,7 +198,7 @@ Load `/.documentation/memory/constitution.md` at step 4. Treat every mandated pr
 10. Completion validation:
     - Verify all required tasks in `tasks.md` are `[X]`
     - Verify every phase has a `**Checkpoint**: Phase complete` line (per step 9 sync rules)
-    - Verify every completed user story in `spec.md` carries the ` ✅ Complete` marker
+    - Verify every completed user story in `spec.md` carries the `✅ Complete` marker
     - Check that implemented features match the original specification
     - Validate that tests pass and coverage meets requirements
     - Confirm the implementation follows the technical plan (and that any deviations are recorded under `## Implementation Notes` in `plan.md`)

--- a/templates/commands/release.md
+++ b/templates/commands/release.md
@@ -598,31 +598,31 @@ To execute this release:
    git commit -m "docs: release v{NEXT_VERSION}"
    ```
 
-5. Tag release:
+1. Tag release:
 
    ```bash
    git tag -a v{NEXT_VERSION} -m "Release v{NEXT_VERSION}"
    ```
 
-6. Push to remote:
+2. Push to remote:
 
    ```bash
    git push origin main --tags
    ```
 
-7. Create GitHub Release (optional):
+3. Create GitHub Release (optional):
 
    ```bash
    gh release create v{NEXT_VERSION} --notes-file .documentation/releases/v{NEXT_VERSION}/release-notes.md
    ```
 
-8. Consumer projects will receive the new version stamp the next time they run:
+4. Consumer projects will receive the new version stamp the next time they run:
 
    ```bash
    devspark upgrade
    ```
 
-9. Run `/devspark.harvest` to complete the cleanup cycle: rewrite spec-linked code comments, consolidate or archive stale docs, and move obsolete artifacts to `/.archive/`.
+5. Run `/devspark.harvest` to complete the cleanup cycle: rewrite spec-linked code comments, consolidate or archive stale docs, and move obsolete artifacts to `/.archive/`.
 
 ## Guidelines
 

--- a/templates/commands/specify.md
+++ b/templates/commands/specify.md
@@ -123,32 +123,34 @@ Given that feature description, do this:
    - `quick-spec` -> `/.devspark/templates/quick-spec-template.md` in installed repos, or `templates/quick-spec-template.md` in source repos
    - Shared validation contract -> `/.devspark/templates/spec-validation-contract.md` in installed repos, or `templates/spec-validation-contract.md` in source repos
 
-4. Follow this execution flow:
-   1. Parse user description from Input
-      If empty: ERROR "No feature description provided"
-   2. Extract key concepts from description
-      Identify: actors, actions, data, constraints
-   3. For unclear aspects:
-      - Make informed guesses based on context and industry standards
-      - Only mark with [NEEDS CLARIFICATION: specific question] if:
-        - The choice significantly impacts feature scope or user experience
-        - Multiple reasonable interpretations exist with different implications
-        - No reasonable default exists
-      - **LIMIT: Maximum 3 [NEEDS CLARIFICATION] markers total**
-      - Prioritize clarifications by impact: scope > security/privacy > user experience > technical details
-   4. Fill User Scenarios & Testing section
-      If no clear user flow: ERROR "Cannot determine user scenarios"
-   5. Generate Functional Requirements
-      Each requirement must be testable
-      Use reasonable defaults for unspecified details (document assumptions in Assumptions section)
-   6. Define Success Criteria
-      Create measurable, technology-agnostic outcomes
-      Include both quantitative metrics (time, performance, volume) and qualitative measures (user satisfaction, task completion)
-      Each criterion must be verifiable without implementation details
-   7. Identify Key Entities (if data involved)
-   8. Return: SUCCESS (spec ready for planning)
+4. **Delegate spec-drafting to the `write-spec` skill** via the adapter contract:
 
-5. Write the specification to SPEC_FILE using the selected template structure, replacing placeholders with concrete details derived from the feature description (arguments) while preserving section order and headings. **Ensure the `**Status**:`field is explicitly set to`Draft`** — this is the starting state of the spec lifecycle (`Draft → In Progress → Complete`). The status will transition to `In Progress` when `/devspark.implement` starts and `Complete` when all tasks are done.
+   Resolve the skill at `templates/skills/write-spec/SKILL.md` (source repos) or
+   `.devspark/templates/skills/write-spec/SKILL.md` (installed repos).
+
+   Pass the following named adapter inputs to the skill:
+
+   - `$FEATURE_DESCRIPTION` — the user's feature description text
+   - `$CONSTITUTION_PATH` — the resolved path to `.documentation/memory/constitution.md`
+     (null when not found)
+   - `$PRIOR_SPEC_SUMMARY` — the JSON output from the skill's context-gathering script
+     (null when unavailable)
+
+   The skill produces a draft `spec.md` body following the drafting procedure defined
+   in `SKILL.md`. The skill limits `[NEEDS CLARIFICATION]` markers to a maximum of
+   three and sets `status: Draft`.
+
+   Multi-app scope resolution (`$APP_SCOPE`) is a command responsibility resolved
+   in step 2 above and is NOT passed into the skill body.
+
+5. Write the skill-produced draft to SPEC_FILE, ensuring:
+   - The `**Status**:` field is explicitly set to `Draft` — this is the starting
+     state of the spec lifecycle (`Draft → In Progress → Complete`). The status
+     will transition to `In Progress` when `/devspark.implement` starts and
+     `Complete` when all tasks are done.
+   - The route-metadata frontmatter (classification, risk_level, target_workflow,
+     required_artifacts, recommended_next_step, required_gates) is applied to the
+     file from step 0 route classification.
 
 6. **Specification Quality Validation**: After writing the initial spec, validate it against the shared specification validation contract plus the quality criteria below:
 

--- a/templates/skills/ADAPTER-contract.md
+++ b/templates/skills/ADAPTER-contract.md
@@ -1,0 +1,141 @@
+# Adapter Contract
+
+This document defines how a DevSpark command invokes an Agent Skill. It covers
+skill discovery, input mapping, output mapping, responsibility split, and
+backward-compatibility rules.
+
+---
+
+## Purpose
+
+A DevSpark command owns lifecycle governance. A skill owns portable capability.
+The adapter contract is the boundary between them. Following this contract
+ensures the skill remains portable — usable in any skills-compatible client
+without DevSpark installed — while the command preserves full governance
+behavior for DevSpark users.
+
+---
+
+## Skill Discovery
+
+A DevSpark command resolves a skill by path:
+
+```text
+templates/skills/<skill-name>/SKILL.md
+```
+
+Path resolution is relative to the repository root. The command is responsible
+for resolving the absolute path before invoking the skill. The skill does not
+know its own installation location.
+
+`devspark skills list` enumerates all sibling directories under
+`templates/skills/` that contain a `SKILL.md`. Clients load only `name` and
+`description` for indexing; the full body is loaded only on activation.
+
+---
+
+## Responsibility Split
+
+This table is authoritative. Any concern not listed here requires a contract
+amendment.
+
+| Concern | Owner |
+| ------- | ----- |
+| Route classification | Command |
+| Branch creation | Command |
+| Multi-app scope resolution | Command |
+| Artifact path placement | Command |
+| Checklist generation | Command |
+| Gate enforcement | Command |
+| Portable task instructions | Skill |
+| Skill discovery metadata (`name`, `description`) | Skill |
+| Capability-specific reasoning workflow | Skill |
+| Context-gathering helper scripts | Skill |
+| Command-to-skill input mapping | Adapter contract (this document) |
+| Skill-to-command output mapping | Adapter contract (this document) |
+
+Multi-app scoping is always a command responsibility. The skill must not receive
+app registry data, multi-app resolution paths, or any DevSpark-specific
+governance state. The command resolves scope first, then passes only the
+resolved context variables listed below.
+
+---
+
+## Input Mapping
+
+The command passes context to the skill through named input variables. These
+variable names are part of the versioned contract surface. Renaming any of them
+requires a `metadata.version` bump in `SKILL.md`.
+
+| Command input | Skill context variable | Notes |
+| ------------- | ---------------------- | ----- |
+| User feature description | `$FEATURE_DESCRIPTION` | Raw user text or resolved summary |
+| Resolved constitution path | `$CONSTITUTION_PATH` | Absolute path; null when not found |
+| Prior-spec summary (from context script) | `$PRIOR_SPEC_SUMMARY` | JSON summary; null when unavailable |
+
+`$FEATURE_DESCRIPTION`, `$CONSTITUTION_PATH`, and `$PRIOR_SPEC_SUMMARY` must
+appear in both the command's delegation block and in this document. They are
+machine-verifiable by the adapter contract test.
+
+Multi-app scope (`$APP_SCOPE`) is resolved by the command and is NOT passed
+into the skill. It is a DevSpark-specific governance concern that does not
+belong in a portable skill body.
+
+---
+
+## Output Mapping
+
+The skill produces a draft artifact. The command places it into the
+DevSpark-governed path.
+
+| Skill output | Command action |
+| ------------ | -------------- |
+| Draft `spec.md` body | Written to `SPEC_FILE` resolved by the command |
+| `[NEEDS CLARIFICATION]` markers | Preserved; command may invoke `/devspark.clarify` |
+| `Assumptions` section | Preserved verbatim in the placed spec |
+
+The skill must not write directly to `SPEC_FILE` or any `.documentation/` path.
+Writing to DevSpark-governed paths is always a command responsibility.
+
+---
+
+## Backward-Compatibility Rules
+
+1. When the skill body is updated, the command's delegation block must be
+   reviewed to confirm the named input variables and output contract are still
+   satisfied.
+2. When a new input variable is added to the skill, add it to the input mapping
+   table above and bump `metadata.version` in `SKILL.md`.
+3. When the skill is removed or renamed, the command must be updated in the same
+   PR. No command may reference a skill that does not exist.
+4. The adapter contract test (`tests/test_adapter_contract.py`) verifies that
+   the named input variables appear in both the command's delegation block and
+   this document. Any contract change that breaks these assertions requires a
+   corresponding test update.
+
+---
+
+## Example: `write-spec` Adapter
+
+The `write-spec` skill is the pilot implementation of this contract.
+
+**Skill path**: `templates/skills/write-spec/SKILL.md`
+
+**Command that delegates**: `templates/commands/specify.md`
+
+**Delegation block** (what the command puts in its body to invoke the skill):
+
+```text
+Resolve the write-spec skill at templates/skills/write-spec/SKILL.md.
+Pass the following named inputs to the skill:
+  $FEATURE_DESCRIPTION — the user's feature request text
+  $CONSTITUTION_PATH — the resolved path to .documentation/memory/constitution.md
+  $PRIOR_SPEC_SUMMARY — the JSON output from the skill's gather-context script
+
+The skill will produce a draft spec body. Place the draft into SPEC_FILE
+as resolved by the command's artifact placement logic.
+```
+
+The command retains all DevSpark lifecycle steps (route classification, branch
+creation, multi-app scoping, artifact placement, checklist generation, gate
+enforcement) and delegates only the spec-drafting reasoning to the skill.

--- a/templates/skills/README.md
+++ b/templates/skills/README.md
@@ -1,0 +1,65 @@
+# DevSpark Agent Skills
+
+This directory contains DevSpark's portable Agent Skills — capability packages
+that comply with the open Agent Skills specification and can run in any
+skills-compatible client without DevSpark installed.
+
+DevSpark treats skills as portable capability packages inside a governed
+lifecycle orchestration system. Commands invoke skills; DevSpark governs the
+lifecycle around them.
+
+```text
+command -> adapter -> skill -> context scripts -> agent reasoning -> artifact
+```
+
+---
+
+## Dual-Surface Model
+
+DevSpark exposes two surfaces for the same capability:
+
+| Surface | Location | Who uses it |
+| ------- | -------- | ----------- |
+| Slash-command | `templates/commands/` | DevSpark users inside a DevSpark-enabled repo |
+| Agent Skill | `templates/skills/` | Any skills-compatible client, with or without DevSpark |
+
+The command performs DevSpark-specific lifecycle work (routing, branch creation,
+artifact placement, gating). The skill performs the portable reasoning. The
+adapter contract defines the handoff.
+
+---
+
+## Skills in This Directory
+
+| Skill | Version | Description |
+| ----- | ------- | ----------- |
+| [write-spec](write-spec/SKILL.md) | 0.1.0 | Draft feature specifications, requirements documents, user stories, acceptance criteria, and validation-ready specs |
+
+---
+
+## Key Documents
+
+- **[ADAPTER-contract.md](ADAPTER-contract.md)** — How DevSpark commands
+  invoke skills: discovery path, input variables, output placement,
+  responsibility split.
+- **[SKILL-validation-contract.md](SKILL-validation-contract.md)** — Rules
+  every `SKILL.md` must satisfy: upstream frontmatter rules, DevSpark addendum,
+  exit-code contract, repair rules.
+- **[references/devspark-skills-guide.md](references/devspark-skills-guide.md)**
+  — Step-by-step contributor guide for adding new DevSpark skills. Start here
+  when building a second skill.
+
+---
+
+## Validation
+
+Run skill validation from the repository root:
+
+```bash
+devspark skills list
+devspark skills validate
+devspark skills validate templates/skills/write-spec
+```
+
+See `SKILL-validation-contract.md` for the exit-code contract and diagnostic
+format.

--- a/templates/skills/SKILL-validation-contract.md
+++ b/templates/skills/SKILL-validation-contract.md
@@ -1,0 +1,142 @@
+# SKILL Validation Contract
+
+This document defines the rules that every `SKILL.md` and skill folder under
+`templates/skills/` must satisfy. Rules are layered: upstream Agent Skills rules
+first, then DevSpark addendum rules.
+
+Source standard: <https://agentskills.io/specification>
+Reviewed: 2026-05-19
+
+---
+
+## Upstream Agent Skills Rules
+
+These rules come directly from the open Agent Skills specification. They apply
+to every skill package regardless of host.
+
+### Required Frontmatter Fields
+
+- `name`: Required. Lowercase letters, numbers, and hyphens only.
+  No leading, trailing, or consecutive hyphens. Maximum 64 characters.
+  Must match the parent directory name exactly.
+- `description`: Required. Non-empty string. Maximum 1024 characters.
+  Must describe both what the skill does and when to invoke it.
+
+### Optional Upstream Fields
+
+- `license`: Optional. Short license identifier or reference to a bundled file.
+- `compatibility`: Optional. Maximum 500 characters when present.
+- `metadata`: Optional in the upstream spec. Arbitrary string key-value map.
+- `allowed-tools`: Optional. Experimental. Space-separated tool string.
+
+---
+
+## DevSpark Addendum Rules
+
+These rules apply to all DevSpark-managed skills. They supplement, not replace,
+the upstream rules.
+
+### Required Additions
+
+- `metadata.version`: Required for every DevSpark skill. Must be a quoted
+  semantic-version string in `MAJOR.MINOR.PATCH` format (e.g., `"0.1.0"`).
+  Partial semver strings (e.g., `"1.0"` missing patch) are rejected.
+  Unquoted values (e.g., `1.0` parsed as a float) are rejected.
+- `metadata.version` must be of type string when parsed with
+  `yaml.safe_load()`. An integer or float type indicates the value is unquoted.
+
+### Prohibited Frontmatter Keys
+
+The following keys are DevSpark command-prompt keys. They must not appear in
+`SKILL.md` frontmatter. Their presence signals a portability violation:
+
+- `handoffs`
+- `scripts` (in the command-prompt sense — not to be confused with the
+  `scripts/` directory inside the skill folder)
+- `classification`
+- `required_gates`
+- `recommended_next_step`
+- `version` (bare top-level — use `metadata.version` instead)
+
+### Body Rules
+
+- Body line count must not exceed 500 lines. Exceeding this limit is a `fail`.
+- Body line count exceeding 400 lines but not 500 is a `warn` (advisory). CI
+  does not block on warnings.
+- Longer material must be moved into `references/` and linked with relative
+  paths from the skill root.
+- The body must not contain any of the following DevSpark-specific strings.
+  Their presence indicates DevSpark lifecycle behavior leaked into a portable
+  skill:
+  - `.devspark/`
+  - `{SCRIPT}`
+  - `FEATURE_DIR`
+  - `{AGENT_SCRIPT}`
+  - `handoffs:`
+
+### Required Body Sections
+
+The body must guide an agent through the core capability without requiring
+DevSpark to be installed. Required sections for spec-drafting skills:
+
+- A context-loading section (what context to gather and how to proceed when
+  unavailable).
+- A drafting procedure section (the workflow the agent executes).
+- An assumptions section (where skipped context is recorded).
+
+### Graceful Degradation
+
+Skills must describe what the agent should do when context-gathering fails.
+Document the fallback explicitly in the body context-loading section.
+
+---
+
+## Three-Tier Exit-Code Table
+
+The `devspark skills validate` command and CI validation tests use this
+exit-code contract:
+
+| Tier | Exit Code | Stdout | Stderr | Meaning |
+| ---- | --------- | ------ | ------ | ------- |
+| `pass` | `0` | One-line summary: name and version | — | All rules satisfied |
+| `warn` | `0` | — | Warning count + advisory details | Body budget pressure (> 400 lines). Does not block CI. |
+| `fail` | `1` | — | Diagnostic per violated rule (see below) | Any frontmatter, prohibited-key, or body-scan rule violated |
+
+### Diagnostic Format for Failures
+
+Each failure diagnostic must use this format:
+
+```text
+[RULE] [OFFENDING-VALUE] message
+```
+
+Examples:
+
+```text
+[name-mismatch] [WriteSpec] name "WriteSpec" does not match directory "write-spec"
+[description-length] [1100] description length 1100 exceeds limit of 1024 characters
+[prohibited-key] [handoffs] frontmatter key "handoffs" is not permitted in SKILL.md
+[version-type] [1.0] metadata.version must be a quoted string; got float
+[version-format] ["1.0"] metadata.version "1.0" does not match MAJOR.MINOR.PATCH
+[body-scan] [.devspark/] body contains DevSpark-specific string ".devspark/"
+[body-length] [512] body line count 512 exceeds maximum of 500
+```
+
+---
+
+## Repair Rules
+
+These rules describe how to correct common violations. They are consistent with
+the style used in `templates/spec-validation-contract.md`.
+
+| Violation | Repair |
+| --------- | ------ |
+| `name` does not match directory | Rename the directory or update `name` to match |
+| `description` over 1024 chars | Shorten; move detail into `references/` |
+| `metadata.version` missing | Add `metadata:\n  version: "0.1.0"` to frontmatter |
+| `metadata.version` is a float | Quote the value: `version: "1.0.0"` |
+| `metadata.version` is partial semver | Add patch component: `"1.0"` → `"1.0.0"` |
+| Prohibited key present | Remove the key from `SKILL.md` frontmatter |
+| DevSpark string in body | Remove or replace with portable equivalent |
+| Body > 500 lines | Move sections to `references/` files |
+| Body > 400 lines | Advisory — consider moving content to `references/` |

--- a/templates/skills/references/devspark-skills-guide.md
+++ b/templates/skills/references/devspark-skills-guide.md
@@ -1,0 +1,312 @@
+# DevSpark Skills Guide
+
+Source standard: <https://agentskills.io/specification>  
+Last reviewed: 2026-05-19
+
+This guide defines how DevSpark uses portable Agent Skills inside this
+repository. The upstream Agent Skills specification remains authoritative for
+portable skill package format. DevSpark adds repository conventions for
+validation, command integration, context engineering, and lifecycle governance.
+
+## DevSpark Position
+
+DevSpark is not a replacement for the Agent Skills ecosystem. DevSpark treats
+skills as portable capability packages inside a governed lifecycle orchestration
+system.
+
+The intended boundary is:
+
+```text
+command -> adapter -> skill -> context scripts -> agent reasoning -> artifact
+```
+
+Commands own DevSpark-specific lifecycle behavior. Skills own portable
+capability instructions. The adapter contract defines how a command invokes a
+skill without leaking DevSpark-only behavior into `SKILL.md`.
+
+## Repository Layout
+
+DevSpark skills live under `templates/skills/`:
+
+```text
+templates/skills/
+├── README.md
+├── ADAPTER-contract.md
+├── SKILL-validation-contract.md
+├── references/
+│   └── devspark-skills-guide.md
+└── <skill-name>/
+    ├── SKILL.md
+    ├── scripts/
+    ├── references/
+    └── assets/
+```
+
+Shared guidance belongs under `templates/skills/references/`. Skill-specific
+guidance belongs under `templates/skills/<skill-name>/references/`.
+
+The first pilot skill is `templates/skills/write-spec/`. It proves that
+`/devspark.specify` can keep the same user-facing command behavior while
+delegating portable spec-drafting instructions to a standalone skill.
+
+## Commands vs Skills
+
+Use this split when designing or reviewing skill work:
+
+| Concern | Owner |
+| ------- | ----- |
+| Slash-command UX | Command |
+| Route classification | Command |
+| Branch creation | Command |
+| Multi-app scope resolution | Command |
+| Artifact path placement | Command |
+| Checklist and gate orchestration | Command |
+| Portable task instructions | Skill |
+| Skill discovery metadata | Skill |
+| Capability-specific reasoning workflow | Skill |
+| Context-gathering helper scripts | Skill |
+| Command-to-skill input and output mapping | Adapter contract |
+
+A skill must be useful outside DevSpark. It must not require branch creation,
+multi-app registry resolution, DevSpark gate execution, or any installed
+DevSpark CLI behavior to perform its core task.
+
+## Skill Package Shape
+
+An Agent Skill is a directory with a required `SKILL.md` file at its root.
+Optional sibling directories can provide supporting resources:
+
+- `scripts/` for executable helper code.
+- `references/` for on-demand documentation.
+- `assets/` for templates, static resources, images, or data files.
+
+Only `SKILL.md` is required by the upstream spec. DevSpark may require
+additional directories for specific skills when the feature spec calls for them.
+For `write-spec`, DevSpark requires `scripts/` because the pilot must
+demonstrate deterministic context gathering.
+
+## SKILL.md Format
+
+`SKILL.md` must start with YAML frontmatter followed by Markdown instructions.
+The frontmatter is the discovery surface loaded by clients before activation.
+The body is loaded only after the agent decides to use the skill.
+
+Minimal DevSpark-managed form:
+
+```yaml
+---
+name: write-spec
+description: Draft feature specifications, requirements documents, user stories, acceptance criteria, and validation-ready specs from a feature request.
+metadata:
+  version: "0.1.0"
+---
+```
+
+DevSpark-managed skills must not use DevSpark command frontmatter keys such as
+`handoffs`, `scripts` in the command-prompt sense, `classification`,
+`required_gates`, or `recommended_next_step`.
+
+## Frontmatter Rules
+
+### Required Upstream Fields
+
+- `name`: Required. Maximum 64 characters. Use lowercase letters, numbers, and
+  hyphens only. It must not start or end with a hyphen, must not contain
+  consecutive hyphens, and must match the parent directory name.
+- `description`: Required. Maximum 1024 characters. It must be non-empty and
+  should say both what the skill does and when to use it.
+
+### Optional Upstream Fields
+
+- `license`: Optional. Short license name or reference to a bundled license
+  file.
+- `compatibility`: Optional. Maximum 500 characters when present. Use only when
+  the skill has meaningful environment requirements.
+- `metadata`: Optional in the upstream spec. Arbitrary string key-value mapping
+  for additional metadata.
+- `allowed-tools`: Optional and experimental. Space-separated tool approval
+  string. Support varies by client.
+
+### DevSpark Addendum
+
+- DevSpark skills must declare `metadata.version` as a quoted semantic-version
+  string.
+- DevSpark skills must not use a top-level `version` field.
+- DevSpark skills must not include DevSpark command-only frontmatter keys.
+- Skill descriptions must be discovery-rich. Include phrases users are likely
+  to use when asking for the capability.
+- `allowed-tools` is deferred for the pilot unless the feature spec is amended.
+
+DevSpark uses `metadata.version` because the upstream spec reserves `metadata`
+for additional key-value properties while keeping the top-level frontmatter
+dialect portable.
+
+## Body Guidance
+
+The skill body contains task instructions. The upstream spec does not impose a
+strict body schema, but recommends keeping `SKILL.md` small and moving detailed
+material into referenced files.
+
+For DevSpark:
+
+- Keep the body at or below 500 lines and roughly 5000 tokens.
+- Put reusable details in `references/` instead of expanding `SKILL.md`.
+- Reference supporting files with relative paths from the skill root.
+- Avoid deep reference chains; keep references one level from `SKILL.md` when
+  practical.
+- State what the skill does when repository context is unavailable.
+- Keep DevSpark lifecycle behavior out of the skill body unless framed as host
+  context supplied by an adapter.
+
+## Context Engineering
+
+DevSpark skills should demonstrate that a capability is more than prompt text.
+When a skill needs repository knowledge, prefer deterministic context gathering
+over freeform exploration.
+
+Context scripts should:
+
+- Produce structured, compact output.
+- Work without mutating the repository.
+- Degrade gracefully outside a DevSpark-enabled repository.
+- Report skipped context explicitly.
+- Avoid blocking the skill when non-critical context cannot be collected.
+
+For `write-spec`, required context includes constitution loading and prior-spec
+summary at minimum. A failure to gather either should be recorded in the
+generated spec assumptions.
+
+## Script Parity
+
+The DevSpark constitution requires platform parity. If a skill bundles
+executable scripts, provide equivalent PowerShell and Bash variants for each
+capability.
+
+Script guidance:
+
+- Keep scripts self-contained.
+- Prefer JSON or another structured format for output.
+- Include clear diagnostics for missing tools, missing files, or non-repository
+  execution.
+- Do not write under `.documentation/` unless the specific workflow and
+  constitution permit it.
+- Do not make script success mandatory unless the feature spec explicitly says
+  the skill cannot proceed without that context.
+
+## References
+
+Shared references under `templates/skills/references/` apply to all DevSpark
+skills. Skill-local references under `templates/skills/<skill-name>/references/`
+apply only to that skill.
+
+Use shared references for:
+
+- DevSpark skills conventions.
+- Upstream Agent Skills rules.
+- Cross-skill validation guidance.
+- Adapter and lifecycle concepts that future skills should reuse.
+
+Use skill-local references for:
+
+- Examples for one capability.
+- Domain-specific instructions.
+- Output templates specific to one skill.
+- Long procedural details that would bloat one `SKILL.md`.
+
+## Assets
+
+The upstream spec allows `assets/` for templates, static resources, images, and
+data files. Add assets only when a reusable artifact is clearer than inline
+Markdown or a reference file.
+
+For DevSpark, assets should be portable with the skill folder. Do not place
+skill assets in `.documentation/`, because `.documentation/` is repository-owned
+work product and must not be installed or modified by framework operations.
+
+## Progressive Disclosure
+
+Agent Skills are designed for staged loading:
+
+1. Clients load `name` and `description` for discovery.
+2. Clients load the full `SKILL.md` body on activation.
+3. Clients load files in `scripts/`, `references/`, or `assets/` only when the
+   task needs them.
+
+This means the `description` must be specific enough to trigger the skill, and
+the body must tell the agent exactly which references or scripts to load for the
+current task.
+
+## Validation Surface
+
+DevSpark skills are validated at three layers:
+
+1. Upstream Agent Skills package rules.
+2. DevSpark skill-validation contract rules.
+3. Adapter contract rules when a DevSpark command invokes the skill.
+
+Expected validation surfaces:
+
+- `templates/skills/SKILL-validation-contract.md` documents the local rules.
+- `devspark skills list` enumerates skills under `templates/skills/`.
+- `devspark skills validate [path]` validates all skills or one skill path.
+- Tests under `tests/` gate skill and adapter contract behavior in CI.
+- Markdownlint gates all committed Markdown.
+
+Validation failures should name the violated rule and offending value. Warnings
+are acceptable for body budget pressure, but portability and frontmatter errors
+must fail validation.
+
+## Adding a Skill
+
+Use this workflow for future DevSpark skills:
+
+1. Start from a spec that justifies why the capability should be a skill.
+2. Confirm the skill has a portable core that can work outside DevSpark.
+3. Define the command-to-skill adapter boundary if a command will invoke it.
+4. Create `templates/skills/<skill-name>/SKILL.md`.
+5. Add skill-local `references/`, `scripts/`, or `assets/` only when needed.
+6. Keep command lifecycle behavior in `templates/commands/`.
+7. Add validation tests before wiring command behavior to the skill.
+8. Run markdownlint and skill validation before review.
+
+Do not auto-convert existing commands into skills without a spec. Avoid tiny
+skills that only wrap one sentence of prompt text; a DevSpark skill should
+package a durable capability with clear context and validation boundaries.
+
+## Pilot Skill: write-spec
+
+The `write-spec` pilot is intentionally narrow:
+
+- It drafts specs only.
+- It does not orchestrate planning or task generation.
+- It must run in a skills-compatible client without DevSpark installed.
+- It must produce a valid `spec.md` against the shared spec validation
+  contract.
+- It must start specs in `Draft` status.
+- It must limit `[NEEDS CLARIFICATION]` markers to three.
+- It must bundle paired PowerShell and Bash context scripts for constitution
+  loading and prior-spec summary.
+- It must degrade gracefully when those scripts cannot gather context.
+- It must not perform branch creation, multi-app scoping, checklist generation,
+  or gate enforcement.
+
+## Review Checklist
+
+Use this checklist while implementing or reviewing DevSpark skills:
+
+- `SKILL.md` exists at the skill root.
+- Frontmatter parses as YAML.
+- `name` matches the parent directory.
+- `name` uses only lowercase letters, numbers, and hyphens.
+- `description` is non-empty, within 1024 characters, and discovery-rich.
+- `metadata.version` exists and is quoted.
+- No top-level `version` field exists.
+- No DevSpark command-only frontmatter keys exist.
+- Body is within the DevSpark budget.
+- Body can guide a non-DevSpark client through the core task.
+- Body references support files using relative paths from the skill root.
+- Shared references are not duplicated in skill-local references.
+- Required scripts have paired PowerShell and Bash implementations.
+- Script failures degrade gracefully.
+- Command lifecycle responsibilities stay in commands or adapters.
+- Markdown passes the repository markdownlint configuration.

--- a/templates/skills/write-spec/SKILL.md
+++ b/templates/skills/write-spec/SKILL.md
@@ -1,0 +1,112 @@
+---
+name: write-spec
+description: Draft feature specifications, requirements documents, user stories, acceptance criteria, and validation-ready specs from a feature request. Use this skill when you need to write a spec, define requirements, capture user stories, or produce a structured specification document.
+metadata:
+  version: "0.1.0"
+---
+
+# write-spec
+
+Draft a structured feature specification from a user's feature request. This
+skill works in any skills-compatible client with or without DevSpark installed.
+
+---
+
+## Context Loading
+
+Before drafting, run the context-gathering script for your platform:
+
+- **PowerShell**: `scripts/gather-context.ps1`
+- **Bash/macOS/Linux**: `bash scripts/gather-context.sh`
+
+Parse the JSON output. If the script exits non-zero, produces empty output, or
+produces non-JSON output, use this fallback and continue without blocking:
+
+```json
+{
+  "constitution_summary": null,
+  "prior_specs": [],
+  "skipped_context": ["script-error"]
+}
+```
+
+The JSON output contains:
+
+- `constitution_summary` — key constraints from the repo constitution, or null
+- `prior_specs` — list of prior spec summaries for naming and scope awareness
+- `skipped_context` — list of context items that could not be gathered
+
+If `constitution_summary` is non-null, apply the listed constraints to the spec.
+If `prior_specs` is non-empty, use the existing numbering pattern for the new
+spec and avoid duplicating solved problems.
+
+---
+
+## Drafting Procedure
+
+Use the spec template in `references/spec-template.md`.
+
+1. Set `name` from the feature request. Generate a sequential number if prior
+   specs are available (e.g., if the last spec was `004-...`, use `005-`).
+2. Set `status: Draft` always. Do not set any other lifecycle state.
+3. Write the **Rationale Summary** — core problem, decision summary, key
+   drivers, tradeoffs considered.
+4. Write **User Stories** — at least one per priority tier in the request.
+   Each story must have: actor, capability, business value, and acceptance
+   scenarios.
+5. Write **Requirements** — MUST-level functional requirements as the minimum
+   viable set. Do not add requirements the user has not implied.
+6. Write **Success Criteria** — measurable outcomes. Each criterion must be
+   verifiable without DevSpark installed.
+7. Add an **Assumptions** section listing anything the spec takes for granted,
+   including any context items listed in `skipped_context`.
+8. Add an **Out of Scope** section. Capture anything explicitly not covered by
+   this spec.
+
+Do NOT include implementation details (frameworks, library versions, file
+paths). Keep the spec technology-agnostic.
+
+Limit `[NEEDS CLARIFICATION]` markers to three. Use them only for genuine
+blocking ambiguities that would prevent drafting a section.
+
+---
+
+## Clarification Format
+
+When a `[NEEDS CLARIFICATION]` marker is needed, follow this format:
+
+```text
+[NEEDS CLARIFICATION]: <question>
+Context: <why this matters for the spec>
+Options: <list 2-3 concrete options when possible>
+```
+
+Consolidate related ambiguities into one marker. Do not add markers for
+stylistic preferences or implementation decisions.
+
+---
+
+## Output
+
+Produce a single `spec.md` file in the current working directory (or the path
+provided by the host client). The file must:
+
+- Pass the shared spec validation contract (see `references/spec-template.md`)
+- Have valid YAML frontmatter with `status: Draft`
+- Contain the four mandatory sections: Rationale Summary, User Stories,
+  Requirements, and Success Criteria
+- Contain no more than three `[NEEDS CLARIFICATION]` markers
+- Contain no implementation details (no language choices, no library versions)
+
+Do not perform branch creation, file moves to governed paths, checklist
+generation, or gate enforcement. Those are DevSpark-command responsibilities.
+
+---
+
+## Assumptions Section
+
+In the produced `spec.md`, always include an Assumptions section that lists:
+
+- Any context gathered or not gathered (from `skipped_context`)
+- Any decisions made without user input
+- Any scope boundaries inferred rather than stated

--- a/templates/skills/write-spec/references/spec-template.md
+++ b/templates/skills/write-spec/references/spec-template.md
@@ -1,0 +1,116 @@
+# Spec Template Reference
+
+Use this template as the structural guide when drafting a `spec.md` with the
+`write-spec` skill.
+
+---
+
+## Frontmatter
+
+```yaml
+---
+classification: full-spec
+risk_level: low|medium|high
+status: Draft
+---
+```
+
+`status` must always be `Draft` when produced by this skill.
+
+---
+
+## Required Sections (in canonical order)
+
+### 1. Feature Name and Header Block
+
+```markdown
+# Feature Specification: <Feature Name>
+
+**Feature Branch**: `<NNN>-<slug>`
+**Created**: YYYY-MM-DD
+**Status**: Draft
+**Input**: <one-sentence description of what the user asked for>
+```
+
+### 2. Rationale Summary
+
+Sub-sections:
+
+- **Core Problem** — What is broken, missing, or suboptimal?
+- **Decision Summary** — What approach is selected and why?
+- **Key Drivers** — Bullet list of motivating factors.
+- **Tradeoffs Considered** — Rejected options with reasons (Option A, Option B,
+  Selected Option).
+
+### 3. User Stories
+
+Each story follows:
+
+```markdown
+### User Story N - <Title> (Priority: P1|P2|P3)
+
+<Actor and goal narrative>
+
+**Why this priority**: <business reason>
+
+**Acceptance Scenarios**:
+
+1. **Given** <precondition>, **When** <action>, **Then** <expected result>.
+2. ...
+```
+
+At least one P1 story is required.
+
+### 4. Requirements
+
+Sub-sections by phase or concern. Each requirement uses MUST or SHOULD:
+
+```markdown
+- **FR-001**: The system MUST...
+- **FR-002**: The system SHOULD...
+```
+
+Do not mix implementation decisions into requirements. Keep requirements
+technology-agnostic.
+
+### 5. Success Criteria
+
+Measurable outcomes keyed to user stories:
+
+```markdown
+- **SC-001**: <Measurable outcome for US1>
+- **SC-002**: <Measurable outcome for US2>
+```
+
+Each criterion must be verifiable without DevSpark.
+
+### 6. Assumptions
+
+```markdown
+## Assumptions
+
+- <Each assumption on its own line>
+- Skipped context: <list items from skipped_context, or "none">
+```
+
+### 7. Out of Scope
+
+```markdown
+## Out of Scope
+
+- <Each out-of-scope item on its own line>
+```
+
+---
+
+## Validation Rules Summary
+
+A `spec.md` passes the shared validation contract when:
+
+- YAML frontmatter is present and parseable.
+- `status: Draft` is present.
+- All four mandatory sections are present: Rationale Summary, User Stories,
+  Requirements, Success Criteria.
+- No more than three `[NEEDS CLARIFICATION]` markers.
+- No implementation details (no framework names, no library versions, no file
+  paths in requirements).

--- a/templates/skills/write-spec/scripts/gather-context.ps1
+++ b/templates/skills/write-spec/scripts/gather-context.ps1
@@ -1,0 +1,104 @@
+#!/usr/bin/env pwsh
+# gather-context.ps1 — Gather repository context for the write-spec skill.
+# Always exits 0. Always emits valid JSON to stdout.
+# Records anything that could not be gathered in the skipped_context array.
+
+$result = @{
+    constitution_summary = $null
+    prior_specs          = @()
+    skipped_context      = @()
+}
+
+# Detect git repository
+$isGitRepo = $false
+try {
+    $gitCheck = git rev-parse --git-dir 2>$null
+    $isGitRepo = $LASTEXITCODE -eq 0
+} catch {
+    $isGitRepo = $false
+}
+
+if (-not $isGitRepo) {
+    $result.skipped_context += "no-git-repo"
+}
+
+# Locate repository root
+$repoRoot = $null
+if ($isGitRepo) {
+    try {
+        $repoRoot = (git rev-parse --show-toplevel 2>$null).Trim()
+    } catch {
+        $repoRoot = $null
+    }
+}
+
+if (-not $repoRoot) {
+    $repoRoot = (Get-Location).Path
+}
+
+# Load constitution summary
+$constitutionPaths = @(
+    Join-Path $repoRoot ".documentation/memory/constitution.md"
+    Join-Path $repoRoot "constitution.md"
+)
+
+$constitutionFound = $false
+foreach ($path in $constitutionPaths) {
+    if (Test-Path $path) {
+        try {
+            $content = Get-Content $path -Raw -ErrorAction Stop
+            # Extract first meaningful paragraph as summary (first 500 chars)
+            $lines = $content -split "`n" | Where-Object { $_.Trim() -ne "" -and -not $_.StartsWith("#") }
+            $summary = ($lines | Select-Object -First 10) -join " "
+            if ($summary.Length -gt 500) {
+                $summary = $summary.Substring(0, 497) + "..."
+            }
+            if ($summary.Length -gt 0) {
+                $result.constitution_summary = $summary
+                $constitutionFound = $true
+                break
+            }
+        } catch {
+            # continue to next path
+        }
+    }
+}
+
+if (-not $constitutionFound) {
+    $result.skipped_context += "constitution-not-found"
+}
+
+# Gather prior specs
+$specsDir = Join-Path $repoRoot ".documentation/specs"
+if (Test-Path $specsDir) {
+    try {
+        $specFolders = Get-ChildItem $specsDir -Directory -ErrorAction Stop |
+            Where-Object { Test-Path (Join-Path $_.FullName "spec.md") } |
+            Sort-Object Name
+        foreach ($folder in $specFolders) {
+            $specFile = Join-Path $folder.FullName "spec.md"
+            try {
+                $specContent = Get-Content $specFile -TotalCount 20 -ErrorAction Stop
+                $titleLine = $specContent | Where-Object { $_ -match "^# " } | Select-Object -First 1
+                $title = if ($titleLine) { $titleLine -replace "^# ", "" } else { $folder.Name }
+                $result.prior_specs += @{
+                    name  = $folder.Name
+                    title = $title
+                }
+            } catch {
+                $result.prior_specs += @{
+                    name  = $folder.Name
+                    title = $folder.Name
+                }
+            }
+        }
+    } catch {
+        $result.skipped_context += "specs-dir-unreadable"
+    }
+} else {
+    $result.skipped_context += "no-specs-dir"
+}
+
+# Emit JSON — always exit 0
+$result | ConvertTo-Json -Depth 5 -Compress
+exit 0

--- a/templates/skills/write-spec/scripts/gather-context.sh
+++ b/templates/skills/write-spec/scripts/gather-context.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+# gather-context.sh — Gather repository context for the write-spec skill.
+# Always exits 0. Always emits valid JSON to stdout.
+# Records anything that could not be gathered in the skipped_context array.
+
+set -euo pipefail
+
+# JSON helpers — build result incrementally
+CONSTITUTION_SUMMARY="null"
+PRIOR_SPECS="[]"
+SKIPPED_CONTEXT="[]"
+
+add_skipped() {
+    local item="$1"
+    if [ "$SKIPPED_CONTEXT" = "[]" ]; then
+        SKIPPED_CONTEXT="[\"$item\"]"
+    else
+        SKIPPED_CONTEXT="${SKIPPED_CONTEXT%]},\"$item\"]"
+    fi
+}
+
+json_escape() {
+    local s="$1"
+    # Escape backslash, double quote, and control characters
+    s="${s//\\/\\\\}"
+    s="${s//\"/\\\"}"
+    s="${s//$'\n'/ }"
+    s="${s//$'\r'/ }"
+    printf '%s' "$s"
+}
+
+# Detect git repository
+REPO_ROOT=""
+if git rev-parse --git-dir >/dev/null 2>&1; then
+    REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || echo "")"
+else
+    add_skipped "no-git-repo"
+fi
+
+if [ -z "$REPO_ROOT" ]; then
+    REPO_ROOT="$(pwd)"
+fi
+
+# Load constitution summary
+CONSTITUTION_FOUND=false
+for CONST_PATH in \
+    "$REPO_ROOT/.documentation/memory/constitution.md" \
+    "$REPO_ROOT/constitution.md"; do
+    if [ -f "$CONST_PATH" ]; then
+        # Extract first meaningful paragraph — first 10 non-empty, non-heading lines
+        SUMMARY=""
+        while IFS= read -r line; do
+            trimmed="${line#"${line%%[! ]*}"}"
+            if [ -n "$trimmed" ] && [ "${trimmed:0:1}" != "#" ]; then
+                if [ -z "$SUMMARY" ]; then
+                    SUMMARY="$trimmed"
+                else
+                    SUMMARY="$SUMMARY $trimmed"
+                fi
+            fi
+            # Stop after collecting enough content
+            word_count=$(echo "$SUMMARY" | wc -w)
+            if [ "$word_count" -gt 80 ]; then
+                break
+            fi
+        done < "$CONST_PATH" 2>/dev/null || true
+
+        if [ -n "$SUMMARY" ]; then
+            # Truncate to 500 chars
+            if [ "${#SUMMARY}" -gt 500 ]; then
+                SUMMARY="${SUMMARY:0:497}..."
+            fi
+            ESCAPED="$(json_escape "$SUMMARY")"
+            CONSTITUTION_SUMMARY="\"$ESCAPED\""
+            CONSTITUTION_FOUND=true
+            break
+        fi
+    fi
+done
+
+if [ "$CONSTITUTION_FOUND" = false ]; then
+    add_skipped "constitution-not-found"
+fi
+
+# Gather prior specs
+SPECS_DIR="$REPO_ROOT/.documentation/specs"
+if [ -d "$SPECS_DIR" ]; then
+    SPECS_JSON=""
+    while IFS= read -r -d '' spec_file; do
+        folder_name="$(basename "$(dirname "$spec_file")")"
+        # Extract title from first heading
+        title_line=""
+        while IFS= read -r line; do
+            if [[ "$line" =~ ^"# " ]]; then
+                title_line="${line:2}"
+                break
+            fi
+        done < "$spec_file" 2>/dev/null || true
+
+        if [ -z "$title_line" ]; then
+            title_line="$folder_name"
+        fi
+
+        escaped_name="$(json_escape "$folder_name")"
+        escaped_title="$(json_escape "$title_line")"
+        entry="{\"name\":\"$escaped_name\",\"title\":\"$escaped_title\"}"
+
+        if [ -z "$SPECS_JSON" ]; then
+            SPECS_JSON="$entry"
+        else
+            SPECS_JSON="$SPECS_JSON,$entry"
+        fi
+    done < <(find "$SPECS_DIR" -name "spec.md" -not -path "*/.archive/*" -print0 2>/dev/null | sort -z)
+
+    if [ -n "$SPECS_JSON" ]; then
+        PRIOR_SPECS="[$SPECS_JSON]"
+    fi
+else
+    add_skipped "no-specs-dir"
+fi
+
+# Emit JSON — always exit 0
+printf '{"constitution_summary":%s,"prior_specs":%s,"skipped_context":%s}\n' \
+    "$CONSTITUTION_SUMMARY" \
+    "$PRIOR_SPECS" \
+    "$SKIPPED_CONTEXT"
+
+exit 0

--- a/tests/test_adapter_contract.py
+++ b/tests/test_adapter_contract.py
@@ -1,0 +1,99 @@
+"""Adapter contract tests for the write-spec skill integration.
+
+Verifies:
+  (a) templates/commands/specify.md references the write-spec skill.
+  (b) The three named adapter input variables appear in both specify.md
+      delegation block and ADAPTER-contract.md (machine-verifiable variable
+      contract per critic-004).
+  (c) Integration-test pass assertion (FR-012c) is a stub pointing to T027;
+      T019 alone does NOT satisfy FR-012(c).
+  (d) specify.md does not duplicate the drafting procedure inline
+      (xfail until T025 refactor completes — enabled in T026).
+"""
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).parent.parent
+SPECIFY_MD = REPO_ROOT / "templates" / "commands" / "specify.md"
+ADAPTER_CONTRACT = REPO_ROOT / "templates" / "skills" / "ADAPTER-contract.md"
+SKILL_MD = REPO_ROOT / "templates" / "skills" / "write-spec" / "SKILL.md"
+
+ADAPTER_VARIABLES = [
+    "$FEATURE_DESCRIPTION",
+    "$CONSTITUTION_PATH",
+    "$PRIOR_SPEC_SUMMARY",
+]
+
+
+class TestAdapterContractFiles:
+    def test_specify_md_exists(self):
+        assert SPECIFY_MD.exists(), f"specify.md not found at {SPECIFY_MD}"
+
+    def test_adapter_contract_exists(self):
+        assert ADAPTER_CONTRACT.exists(), (
+            f"ADAPTER-contract.md not found at {ADAPTER_CONTRACT}"
+        )
+
+    def test_skill_md_exists(self):
+        assert SKILL_MD.exists(), (
+            f"write-spec/SKILL.md not found at {SKILL_MD}"
+        )
+
+
+class TestAdapterVariableContract:
+    """Assert the three named adapter input variables appear in ADAPTER-contract.md.
+
+    critic-004: variable names are part of the versioned contract surface.
+    They must be machine-verifiable in the contract document.
+    After T025 refactor, they must also appear in specify.md's delegation block.
+    """
+
+    def test_feature_description_in_adapter_contract(self):
+        content = ADAPTER_CONTRACT.read_text(encoding="utf-8")
+        assert "$FEATURE_DESCRIPTION" in content, (
+            "ADAPTER-contract.md must reference $FEATURE_DESCRIPTION"
+        )
+
+    def test_constitution_path_in_adapter_contract(self):
+        content = ADAPTER_CONTRACT.read_text(encoding="utf-8")
+        assert "$CONSTITUTION_PATH" in content, (
+            "ADAPTER-contract.md must reference $CONSTITUTION_PATH"
+        )
+
+    def test_prior_spec_summary_in_adapter_contract(self):
+        content = ADAPTER_CONTRACT.read_text(encoding="utf-8")
+        assert "$PRIOR_SPEC_SUMMARY" in content, (
+            "ADAPTER-contract.md must reference $PRIOR_SPEC_SUMMARY"
+        )
+
+    def test_adapter_variables_in_specify_delegation_block(self):
+        content = SPECIFY_MD.read_text(encoding="utf-8")
+        missing = [v for v in ADAPTER_VARIABLES if v not in content]
+        assert not missing, (
+            f"specify.md delegation block is missing adapter variables: {missing}"
+        )
+
+    def test_specify_does_not_duplicate_drafting_procedure(self):
+        content = SPECIFY_MD.read_text(encoding="utf-8")
+        # After 2D refactor, the inline drafting steps 1-8 must not appear.
+        # The old inline procedure contained this specific text that is now removed.
+        inline_procedure_marker = "Parse user description from Input"
+        assert inline_procedure_marker not in content, (
+            "specify.md must not contain the old inline drafting procedure after 2D refactor"
+        )
+
+
+class TestSpecifyReferencesSkill:
+    """Assert specify.md references the write-spec skill.
+
+    Note: FR-012(c) integration-test pass assertion is a stub here.
+    It is not fully enforced until T027 runs the full integration suite
+    against the refactored command. T019 alone does not satisfy FR-012(c).
+    """
+
+    def test_specify_references_write_spec(self):
+        content = SPECIFY_MD.read_text(encoding="utf-8")
+        assert "write-spec" in content, (
+            "specify.md must reference the write-spec skill after 2D refactor"
+        )

--- a/tests/test_harness_adapters_contract.py
+++ b/tests/test_harness_adapters_contract.py
@@ -80,6 +80,7 @@ def main() -> None:
 
         expected_commands = {
             "claude_code": "claude",
+            "codex": "codex",
             "copilot": "copilot",
             "cursor": "cursor-agent",
         }
@@ -103,7 +104,12 @@ def main() -> None:
             with patch("shutil.which", return_value=f"/tmp/{executable}"), patch("subprocess.run", side_effect=fake_run):
                 response = adapter.execute(_make_step(prompt_path), context, telemetry)
 
-            assert captured["command"] == [executable, "--print"]
+            expected_command = (
+                [executable, "exec", "--sandbox", "workspace-write", "-"]
+                if adapter_name == "codex"
+                else [executable, "--print"]
+            )
+            assert captured["command"] == expected_command
             assert captured["cwd"] == context.repo_root
             assert captured["input"] == prompt_text
             assert response.output_text == f"{adapter_name} output"

--- a/tests/test_installation_manifest_contract.py
+++ b/tests/test_installation_manifest_contract.py
@@ -1,0 +1,59 @@
+"""Contract validation for agent-specific installation manifest checks."""
+
+from __future__ import annotations
+
+import sys
+import tempfile
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent.parent
+SRC_ROOT = ROOT / "src"
+if str(SRC_ROOT) not in sys.path:
+    sys.path.insert(0, str(SRC_ROOT))
+
+from devspark_cli._template import validate_installation_manifest
+
+
+def _write_command(repo: Path, name: str) -> None:
+    command_dir = repo / ".devspark" / "defaults" / "commands"
+    command_dir.mkdir(parents=True, exist_ok=True)
+    (command_dir / f"devspark.{name}.md").write_text(f"# {name}\n", encoding="utf-8")
+
+
+def main() -> None:
+    with tempfile.TemporaryDirectory() as temp_dir:
+        repo = Path(temp_dir)
+        _write_command(repo, "specify")
+        _write_command(repo, "plan")
+
+        copilot_dir = repo / ".github" / "agents"
+        copilot_dir.mkdir(parents=True, exist_ok=True)
+        (copilot_dir / "devspark.specify.agent.md").write_text("# specify\n", encoding="utf-8")
+        (copilot_dir / "devspark.plan.agent.md").write_text("# plan\n", encoding="utf-8")
+
+        codex_dir = repo / ".codex" / "prompts"
+        codex_dir.mkdir(parents=True, exist_ok=True)
+        (codex_dir / "devspark.specify.md").write_text("# specify\n", encoding="utf-8")
+        (codex_dir / "devspark.plan.md").write_text("# plan\n", encoding="utf-8")
+
+        copilot = validate_installation_manifest(repo, "copilot")
+        assert copilot["valid"]
+        assert copilot["shim_count"] == 2
+        assert copilot["shim_dir"].endswith(".github\\agents") or copilot["shim_dir"].endswith(".github/agents")
+
+        codex = validate_installation_manifest(repo, "codex")
+        assert codex["valid"]
+        assert codex["shim_count"] == 2
+        assert codex["shim_dir"].endswith(".codex\\prompts") or codex["shim_dir"].endswith(".codex/prompts")
+
+        (codex_dir / "devspark.plan.md").unlink()
+        codex_missing = validate_installation_manifest(repo, "codex")
+        assert not codex_missing["valid"]
+        assert codex_missing["missing_shims"] == ["plan"]
+
+    print("Installation manifest contract validated.")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_skill_contract.py
+++ b/tests/test_skill_contract.py
@@ -1,0 +1,277 @@
+"""Contract tests for Agent Skills under templates/skills/.
+
+Discovers every directory under templates/skills/ that contains a SKILL.md,
+parses its YAML frontmatter using yaml.safe_load() (SafeLoader avoids YAML 1.1
+boolean surprises), and asserts all rules from SKILL-validation-contract.md.
+
+Includes a deliberate-violation fixture set to confirm each rule fails correctly.
+"""
+import re
+import textwrap
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).parent.parent
+SKILLS_DIR = REPO_ROOT / "templates" / "skills"
+
+PROHIBITED_KEYS = {
+    "handoffs",
+    "scripts",
+    "classification",
+    "required_gates",
+    "recommended_next_step",
+    "version",
+}
+
+PROHIBITED_BODY_STRINGS = [
+    ".devspark/",
+    "{SCRIPT}",
+    "FEATURE_DIR",
+    "{AGENT_SCRIPT}",
+    "handoffs:",
+]
+
+NAME_REGEX = re.compile(r"^[a-z0-9]+(-[a-z0-9]+)*$")
+VERSION_REGEX = re.compile(r"^\d+\.\d+\.\d+$")
+
+BODY_WARN_LINES = 400
+BODY_FAIL_LINES = 500
+
+
+def discover_skills():
+    """Return list of (skill_dir, skill_name) for all valid skill directories."""
+    if not SKILLS_DIR.exists():
+        return []
+    return [
+        (d, d.name)
+        for d in sorted(SKILLS_DIR.iterdir())
+        if d.is_dir() and (d / "SKILL.md").exists()
+    ]
+
+
+def parse_skill(skill_dir: Path):
+    """Parse SKILL.md and return (frontmatter_dict, body_lines)."""
+    content = (skill_dir / "SKILL.md").read_text(encoding="utf-8")
+    if not content.startswith("---"):
+        return {}, content.splitlines()
+    parts = content.split("---", 2)
+    if len(parts) < 3:
+        return {}, content.splitlines()
+    frontmatter = yaml.safe_load(parts[1]) or {}
+    body = parts[2]
+    return frontmatter, body.splitlines()
+
+
+@pytest.mark.parametrize("skill_dir,skill_name", discover_skills())
+class TestSkillContract:
+    def test_name_present(self, skill_dir, skill_name):
+        fm, _ = parse_skill(skill_dir)
+        assert "name" in fm, "[name-missing] frontmatter must contain 'name' field"
+
+    def test_name_matches_directory(self, skill_dir, skill_name):
+        fm, _ = parse_skill(skill_dir)
+        name = fm.get("name", "")
+        assert name == skill_name, (
+            f"[name-mismatch] [{name}] name '{name}' does not match "
+            f"directory '{skill_name}'"
+        )
+
+    def test_name_format(self, skill_dir, skill_name):
+        fm, _ = parse_skill(skill_dir)
+        name = fm.get("name", "")
+        assert NAME_REGEX.match(name), (
+            f"[name-format] [{name}] name must match [a-z0-9]+(-[a-z0-9]+)* "
+            f"— no leading/trailing/consecutive hyphens, no uppercase"
+        )
+
+    def test_name_length(self, skill_dir, skill_name):
+        fm, _ = parse_skill(skill_dir)
+        name = fm.get("name", "")
+        assert len(name) <= 64, (
+            f"[name-length] [{len(name)}] name length {len(name)} exceeds limit of 64"
+        )
+
+    def test_description_present(self, skill_dir, skill_name):
+        fm, _ = parse_skill(skill_dir)
+        assert "description" in fm, (
+            "[description-missing] frontmatter must contain 'description' field"
+        )
+
+    def test_description_non_empty(self, skill_dir, skill_name):
+        fm, _ = parse_skill(skill_dir)
+        desc = fm.get("description", "")
+        assert desc and len(str(desc).strip()) > 0, (
+            "[description-empty] description must be non-empty"
+        )
+
+    def test_description_length(self, skill_dir, skill_name):
+        fm, _ = parse_skill(skill_dir)
+        desc = str(fm.get("description", ""))
+        assert len(desc) <= 1024, (
+            f"[description-length] [{len(desc)}] description length {len(desc)} "
+            f"exceeds limit of 1024 characters"
+        )
+
+    def test_metadata_version_present(self, skill_dir, skill_name):
+        fm, _ = parse_skill(skill_dir)
+        metadata = fm.get("metadata", {})
+        assert isinstance(metadata, dict) and "version" in metadata, (
+            "[version-missing] metadata.version is required for DevSpark skills"
+        )
+
+    def test_metadata_version_is_string(self, skill_dir, skill_name):
+        fm, _ = parse_skill(skill_dir)
+        metadata = fm.get("metadata", {})
+        version = metadata.get("version")
+        assert isinstance(version, str), (
+            f"[version-type] [{version!r}] metadata.version must be a quoted string; "
+            f"got {type(version).__name__}"
+        )
+
+    def test_metadata_version_semver(self, skill_dir, skill_name):
+        fm, _ = parse_skill(skill_dir)
+        metadata = fm.get("metadata", {})
+        version = str(metadata.get("version", ""))
+        assert VERSION_REGEX.match(version), (
+            f"[version-format] [{version!r}] metadata.version '{version}' does not "
+            f"match MAJOR.MINOR.PATCH (e.g., '0.1.0')"
+        )
+
+    def test_no_prohibited_keys(self, skill_dir, skill_name):
+        fm, _ = parse_skill(skill_dir)
+        found = PROHIBITED_KEYS & set(fm.keys())
+        assert not found, (
+            f"[prohibited-key] {sorted(found)} frontmatter key(s) are not permitted "
+            f"in SKILL.md: {sorted(found)}"
+        )
+
+    def test_body_length_pass(self, skill_dir, skill_name):
+        _, body_lines = parse_skill(skill_dir)
+        count = len(body_lines)
+        assert count <= BODY_FAIL_LINES, (
+            f"[body-length] [{count}] body line count {count} exceeds maximum of "
+            f"{BODY_FAIL_LINES}"
+        )
+
+    def test_body_portability_scan(self, skill_dir, skill_name):
+        _, body_lines = parse_skill(skill_dir)
+        body = "\n".join(body_lines)
+        violations = [s for s in PROHIBITED_BODY_STRINGS if s in body]
+        assert not violations, (
+            f"[body-scan] {violations} body contains DevSpark-specific string(s) "
+            f"that indicate portability violations: {violations}"
+        )
+
+
+class TestSkillContractViolationFixtures:
+    """Deliberate-violation fixtures — each must fail with a named rule message."""
+
+    def _parse_fixture(self, content: str):
+        content = textwrap.dedent(content).lstrip()
+        if not content.startswith("---"):
+            return {}, content.splitlines()
+        parts = content.split("---", 2)
+        if len(parts) < 3:
+            return {}, content.splitlines()
+        fm = yaml.safe_load(parts[1]) or {}
+        body = parts[2]
+        return fm, body.splitlines()
+
+    def test_fixture_uppercase_name_fails_format(self):
+        content = """\
+            ---
+            name: WriteSpec
+            description: A valid description for testing.
+            metadata:
+              version: "0.1.0"
+            ---
+            Body text here.
+        """
+        fm, _ = self._parse_fixture(content)
+        name = fm.get("name", "")
+        assert not NAME_REGEX.match(name), (
+            "Expected uppercase name to fail NAME_REGEX"
+        )
+
+    def test_fixture_description_too_long_fails(self):
+        content = f"""\
+            ---
+            name: write-spec
+            description: {'x' * 1025}
+            metadata:
+              version: "0.1.0"
+            ---
+            Body text here.
+        """
+        fm, _ = self._parse_fixture(content)
+        desc = str(fm.get("description", ""))
+        assert len(desc) > 1024, "Expected description length to exceed 1024"
+
+    def test_fixture_unquoted_float_version_fails_type(self):
+        content = """\
+            ---
+            name: write-spec
+            description: A valid description.
+            metadata:
+              version: 1.0
+            ---
+            Body text here.
+        """
+        fm, _ = self._parse_fixture(content)
+        metadata = fm.get("metadata", {})
+        version = metadata.get("version")
+        assert not isinstance(version, str), (
+            "Expected unquoted 1.0 to parse as float (not string)"
+        )
+
+    def test_fixture_partial_semver_fails_regex(self):
+        content = """\
+            ---
+            name: write-spec
+            description: A valid description.
+            metadata:
+              version: "1.0"
+            ---
+            Body text here.
+        """
+        fm, _ = self._parse_fixture(content)
+        metadata = fm.get("metadata", {})
+        version = str(metadata.get("version", ""))
+        assert not VERSION_REGEX.match(version), (
+            "Expected partial semver '1.0' to fail VERSION_REGEX"
+        )
+
+    def test_fixture_prohibited_key_fails(self):
+        content = """\
+            ---
+            name: write-spec
+            description: A valid description.
+            metadata:
+              version: "0.1.0"
+            handoffs:
+              - label: Next step
+            ---
+            Body text here.
+        """
+        fm, _ = self._parse_fixture(content)
+        found = PROHIBITED_KEYS & set(fm.keys())
+        assert found, "Expected prohibited key 'handoffs' to be detected"
+
+    def test_fixture_body_with_devspark_string_fails(self):
+        content = """\
+            ---
+            name: write-spec
+            description: A valid description.
+            metadata:
+              version: "0.1.0"
+            ---
+            Run {SCRIPT} to gather context from .devspark/ directory.
+        """
+        _, body_lines = self._parse_fixture(content)
+        body = "\n".join(body_lines)
+        violations = [s for s in PROHIBITED_BODY_STRINGS if s in body]
+        assert violations, (
+            "Expected DevSpark-specific strings to be detected in body"
+        )


### PR DESCRIPTION
## Summary

Delivers the `write-spec` Agent Skill and the dual-surface model foundation for DevSpark (feature [003-add-first-skill](https://github.com/markhazleton/devspark/blob/003-add-first-skill/.documentation/specs/003-add-first-skill/spec.md), full-spec, medium risk):

- Introduces `templates/skills/` as a portable Agent Skills surface alongside `templates/commands/`
- Ships one portable pilot skill (`write-spec`, spec-drafting only) that complies with the open Agent Skills specification and runs in any skills-compatible client without DevSpark installed
- Refactors `/devspark.specify` to delegate spec-drafting to the `write-spec` skill via a documented adapter contract — existing user-facing UX is unchanged
- Adds `devspark skills list` and `devspark skills validate` CLI subcommands
- Adds 28 new tests enforcing skill and adapter contract compliance in CI

## Changes

21 files changed, 4152 insertions(+), 26 deletions(-)

**New — Foundation (2A):**
- `templates/skills/ADAPTER-contract.md` — responsibility split, input mapping, backward-compatibility rules
- `templates/skills/SKILL-validation-contract.md` — three-tier exit-code contract, prohibited keys, repair rules
- `templates/skills/README.md` — dual-surface model landing page
- `templates/skills/references/devspark-skills-guide.md` — contributor walkthrough (SC-005)

**New — Skill (2B):**
- `templates/skills/write-spec/SKILL.md` — portable skill (112 lines, open-spec compliant, no prohibited keys)
- `templates/skills/write-spec/references/spec-template.md` — spec structural reference
- `templates/skills/write-spec/scripts/gather-context.ps1` — PowerShell context script (always exits 0, valid JSON)
- `templates/skills/write-spec/scripts/gather-context.sh` — Bash equivalent (§VI Platform Parity)

**New — Tests + CLI (2C):**
- `tests/test_skill_contract.py` — 19 tests + 6 deliberate-violation fixtures, uses yaml.safe_load()
- `tests/test_adapter_contract.py` — 9 tests: file existence, variable contract, delegation assertion
- `src/devspark_cli/commands/skills.py` — `devspark skills list` and `devspark skills validate [path]`

**Modified — Refactor (2D):**
- `templates/commands/specify.md` — delegates spec-drafting to write-spec skill via adapter contract; all lifecycle steps preserved
- `src/devspark_cli/_app.py` — wires skills_app
- `README.md`, `CLAUDE.md` — FR-019 positioning statement and dual-surface model pointers

## Task Completion

**35/35 tasks complete.** All 6 phases delivered: 2A Foundation → 2B Skill → 2C Tests+CLI → 2D Refactor → Polish.

Checklist: 18/19 items complete (see Gate Acknowledgements for the 1 stale item).

## Quality Gates

| Gate | Status | Summary |
|------|--------|---------|
| analyze | ✅ PASS | 27/27 requirements covered; 3 medium findings resolved. All closed. |
| critic | ✅ PASS | 0 showstoppers, 0 critical. All 8 findings (4 high, 4 medium) resolved. |
| Test suite | ✅ PASS | 159 passed, 1 skipped, 0 failures (baseline: 131). Zero regressions. |
| markdownlint | ✅ PASS | 0 errors on all new and modified files. |

## Gate Acknowledgements

**Gate**: `checklists/requirements.md` — 1 incomplete item ("No [NEEDS CLARIFICATION] markers remain"). This item was flagged based on a pre-clarifications-session state of the spec. After review, no actual `[NEEDS CLARIFICATION]` markers remain in `spec.md`; the two occurrences found by grep are in instruction prose (FR-006 rule text and acceptance scenario wording), not open markers. FR-020 distribution surface was resolved via the Clarifications session 2026-05-19 (in-repo only). **Decision**: Proceed — stale item, underlying concern resolved. Recorded by `/devspark.tasks` on 2026-05-19.

## Spec Reference

[`.documentation/specs/003-add-first-skill/spec.md`](https://github.com/markhazleton/devspark/blob/003-add-first-skill/.documentation/specs/003-add-first-skill/spec.md) — Status: Complete

## Reviewer Focus Areas

1. **Adapter contract clarity (2A)**: Does `ADAPTER-contract.md` cleanly separate portable skill reasoning from DevSpark lifecycle concerns (branch creation, multi-app scoping, gate enforcement)?
2. **Skill portability (2B)**: Does `SKILL.md` use only open-spec frontmatter (no DevSpark keys in `SKILL.md`)? Is the body within the 500-line budget?
3. **Context engineering (2B)**: Do the bundled scripts demonstrate deterministic context gathering (not just prompt delivery)?
4. **Refactor parity (2D)**: Do the existing `/devspark.specify` integration tests still pass unchanged? (Verified: 2 passed.)
5. **Scope discipline**: Exactly one skill (`write-spec`, spec-drafting only). Reject any attempt to expand scope to `plan` or `tasks` skills inside this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)