### PR TITLE
Add Bash address-pr-review contract coverage

### DIFF
--- a/templates/commands/address-pr-review.md
+++ b/templates/commands/address-pr-review.md
@@ -30,7 +30,7 @@ This command is the **author-side companion** to `/devspark.pr-review`. It helps
 
 - Existing PR review file at `/.documentation/specs/pr-review/pr-{PR_ID}.md`
 - Git repository with the PR source branch checked out
-- PowerShell 7+ (`pwsh`) available for the gate helper script
+- PowerShell 7+ (`pwsh`) on Windows, or Bash on macOS/Linux, for the gate helper script
 
 ## Outline
 
@@ -38,7 +38,7 @@ This command is the **author-side companion** to `/devspark.pr-review`. It helps
 
 > **Script Resolution**: Before running `{SCRIPT}`, apply the 2-tier override check — if `.documentation/scripts/powershell/address-pr-review.ps1` (PowerShell) or `.documentation/scripts/bash/address-pr-review.sh` (Bash) exists on disk, run that file instead, preserving all arguments. Team overrides in `.documentation/scripts/` always take priority over `.devspark/scripts/`.
 
-1. Run `{SCRIPT}` with `-PrId {PR_ID} -Json`.
+1. Run `{SCRIPT}` with the PR id and JSON output enabled (`-PrId {PR_ID} -Json` on PowerShell, `--pr-id {PR_ID} --json` on Bash).
 2. Fail fast if `/.documentation/specs/pr-review/pr-{PR_ID}.md` is missing.
 3. Parse open findings from checklist lines matching:
    - `- [ ] **C-##**`
@@ -77,7 +77,7 @@ For each selected finding:
 
 ### Phase 4 — Commit code fixes (isolation gate #1)
 
-1. Run gate script with `-Gate code-only` before commit.
+1. Run gate script with code-only mode before commit (`-Gate code-only` on PowerShell, `--gate code-only` on Bash).
 2. If the gate fails, **abort** and print offending staged paths.
 3. Review staged diff and commit with:
 
@@ -104,7 +104,7 @@ Then update metadata:
 
 ### Phase 6 — Commit review file (isolation gate #2)
 
-1. Run gate script with `-Gate review-only` before commit.
+1. Run gate script with review-only mode before commit (`-Gate review-only` on PowerShell, `--gate review-only` on Bash).
 2. If the gate fails, **abort** and print offending staged paths.
 3. Commit with:
 

--- a/tests/test_address_pr_review_contract.py
+++ b/tests/test_address_pr_review_contract.py
@@ -18,6 +18,7 @@ def _read(rel_path: str) -> str:
 def main() -> None:
     command = _read("templates/commands/address-pr-review.md")
     script = _read("scripts/powershell/address-pr-review.ps1")
+    bash_script = _read("scripts/bash/address-pr-review.sh")
     hook = _read(".devspark/hooks/pre-commit-review-isolation.ps1")
     hook_readme = _read(".devspark/hooks/README.md")
     pr_review = _read("templates/commands/pr-review.md")
@@ -30,6 +31,10 @@ def main() -> None:
 
     assert "-Gate code-only" in command
     assert "-Gate review-only" in command
+    assert "--pr-id {PR_ID} --json" in command
+    assert "--gate code-only" in command
+    assert "--gate review-only" in command
+    assert "sh: .devspark/scripts/bash/address-pr-review.sh --pr-id $ARGUMENTS --json" in command
     assert "git log HEAD~2..HEAD --name-only" in command
     assert "Nothing to address." in command
     assert "/devspark.pr-review UPDATE" in command
@@ -39,6 +44,10 @@ def main() -> None:
     assert "Code commit gate failed" in script
     assert "Review commit gate failed" in script
     assert "^\\s*-\\s*\\[\\s\\]\\s+\\*\\*((C|H|M|L|CON)-\\d{2})\\*\\*" in script
+    assert "--pr-id" in bash_script
+    assert "--gate" in bash_script
+    assert "Code commit gate failed" in bash_script
+    assert "Review commit gate failed" in bash_script
 
     assert "PR review files must be committed in isolation" in hook
     assert ".git/hooks/pre-commit" in hook_readme

--- a/tests/test_script_parity_contract.py
+++ b/tests/test_script_parity_contract.py
@@ -28,6 +28,8 @@ def main() -> None:
     ps_release_context = _read('scripts/powershell/release-context.ps1')
     bash_release_history = _read('scripts/bash/release-history-context.sh')
     ps_release_history = _read('scripts/powershell/release-history-context.ps1')
+    bash_address_pr_review = _read('scripts/bash/address-pr-review.sh')
+    ps_address_pr_review = _read('scripts/powershell/address-pr-review.ps1')
 
     assert 'get_markdown_frontmatter()' in bash_common
     assert 'get_markdown_frontmatter_value()' in bash_common
@@ -68,6 +70,10 @@ def main() -> None:
     assert 'RECOVERED_QUICKFIXES' in ps_release_history
     assert 'MERGED_PR_NUMBERS' in ps_release_history
     assert 'PR_REVIEW_SUMMARY' in ps_release_history
+
+    for token in ('Code commit gate failed', 'Review commit gate failed'):
+        assert token in bash_address_pr_review
+        assert token in ps_address_pr_review
 
     # T064: run-workflow.* and generate-atomic-shims.* parity
     bash_run = _read('scripts/bash/run-workflow.sh')


### PR DESCRIPTION
## Summary
- remove script-preference gating from all five quickstarts and install both PowerShell and Bash script sets unconditionally
- include the Bash address-pr-review helper in quickstart installs and use it for the sh command path
- make upgrade/repair guidance explicitly sync both script directories
- add contract coverage for the native Bash address-pr-review path

## Validation
- python tests/test_address_pr_review_contract.py
- python tests/test_script_parity_contract.py
- git diff --check

Note: python tests/test_documentation_audit.py still fails on pre-existing broken relative links under .documentation/ that are outside this change.

Closes #45