### PR TITLE
Feature Specification: Participant Roles

### DIFF
--- a/.documentation/constitution-guide.md
+++ b/.documentation/constitution-guide.md
@@ -6,6 +6,10 @@ The **project constitution** is the foundational document that defines your proj
 
 The constitution lives at `/.documentation/memory/constitution.md` in your project root.
 
+Participant metadata, when present in specs, plans, or tasks, is advisory
+responsibility context. It never weakens constitution authority, app-level
+governance, quality gates, or the existing prompt and script resolution rules.
+
 ## Why a Constitution?
 
 Without clear guiding principles, AI agents and developers can make inconsistent decisions. The constitution provides:

--- a/.documentation/implementation-lifecycle.md
+++ b/.documentation/implementation-lifecycle.md
@@ -42,6 +42,23 @@ After bootstrap, run the standard implementation lifecycle in chat:
 11. `/devspark.pr-review UPDATE`
 12. Merge PR after approval
 
+### Lifecycle Terminology
+
+DevSpark uses distinct terms for workflow concepts:
+
+- **Prompt**: the workflow command surface that owns lifecycle orchestration.
+- **Agent**: an AI runtime or client integration that executes prompts.
+- **Skill**: a portable capability package a prompt may delegate to.
+- **Participant**: a human or AI-filled team member with responsibility in a
+  workflow.
+- **Role**: a responsibility label for a participant, such as owner, planner,
+  implementer, reviewer, critic, or scribe.
+
+Participant metadata is advisory and artifact-only. It can record responsibility
+context in specs, plans, or tasks, but it does not affect command execution,
+prompt resolution, script resolution, gate enforcement, or command output.
+Customization layers and precedence are unchanged.
+
 ### Route-Aware Intake
 
 `/devspark.specify` is the canonical starting point for new work. It classifies the request, explains the recommendation, and asks the user to confirm or override it.

--- a/.documentation/specs/001-participant-roles/checklists/requirements.md
+++ b/.documentation/specs/001-participant-roles/checklists/requirements.md
@@ -1,0 +1,42 @@
+# Specification Quality Checklist: Participant Roles
+
+**Purpose**: Validate specification completeness and quality before proceeding
+to planning
+**Created**: 2026-05-31
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [X] Frontmatter matches the shared validation contract
+- [X] Required headings for the selected route are present in canonical order
+- [X] Status line uses a valid lifecycle state
+- [X] No implementation details leak into product requirements
+- [X] Focused on user value and governance clarity
+- [X] Written for DevSpark stakeholders and maintainers
+- [X] All mandatory sections completed
+
+## Requirement Completeness
+
+- [X] No [NEEDS CLARIFICATION] markers remain
+- [X] Requirements are testable and unambiguous
+- [X] Success criteria are measurable
+- [X] Success criteria are technology-agnostic
+- [X] All acceptance scenarios are defined
+- [X] Edge cases are identified
+- [X] Scope is clearly bounded
+- [X] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [X] All functional requirements have clear acceptance criteria
+- [X] User scenarios cover primary flows
+- [X] Feature meets measurable outcomes defined in Success Criteria
+- [X] No participant concept changes existing customization layers
+- [X] Optional participant metadata is warning-only and non-blocking
+
+## Notes
+
+- The specification intentionally defers participant-based workflow behavior to
+  a later approved spec.
+- The existing personal, team, and stock customization process is explicitly
+  preserved.

--- a/.documentation/specs/001-participant-roles/contracts/participant-metadata.md
+++ b/.documentation/specs/001-participant-roles/contracts/participant-metadata.md
@@ -1,0 +1,92 @@
+# Contract: Participant Metadata
+
+## Purpose
+
+Define the optional `participants` YAML frontmatter shape used in stock
+DevSpark examples for specs, plans, and tasks.
+
+## Applicability
+
+This contract applies to stock template examples only:
+
+- `templates/spec-template.md`
+- `templates/quick-spec-template.md`
+- `templates/plan-template.md`
+- `templates/tasks-template.md`
+
+It does not require existing generated artifacts to include participant
+metadata.
+
+## Required Behavior
+
+1. Existing artifacts without `participants` metadata remain valid.
+2. Existing tests and fixtures without `participants` metadata continue to pass.
+3. Participant metadata does not change prompt resolution, script resolution,
+   workflow routing, command output, or gate enforcement.
+4. Participant examples must not redefine `agent` as a team member.
+
+## Stock Example Shape
+
+Use optional YAML frontmatter:
+
+```yaml
+participants:
+  owner:
+    kind: human
+  planner:
+    kind: ai
+  implementer:
+    kind: ai
+  reviewer:
+    kind: human
+  critic:
+    kind: ai
+  scribe:
+    kind: ai
+```
+
+Short examples may use compact role-to-kind values:
+
+```yaml
+participants:
+  owner: human
+  planner: ai
+  reviewer: human
+```
+
+## Optional Display Labels
+
+Teams may add an optional `name` field when they choose to carry local display
+labels:
+
+```yaml
+participants:
+  reviewer:
+    kind: human
+    name: "Human Reviewer"
+```
+
+Stock documentation must not recommend storing personally identifying
+information. Teams that add personal data own their own PII handling.
+
+## Advisory Role Set
+
+Stock examples should use these advisory roles:
+
+- `owner`
+- `planner`
+- `implementer`
+- `reviewer`
+- `critic`
+- `scribe`
+
+Other role names remain valid unless a future approved spec introduces
+validation.
+
+## Non-Goals
+
+- No participant routing.
+- No reviewer lockout behavior.
+- No participant registry.
+- No participant inheritance or override model.
+- No command output summary.

--- a/.documentation/specs/001-participant-roles/data-model.md
+++ b/.documentation/specs/001-participant-roles/data-model.md
@@ -1,0 +1,117 @@
+# Data Model: Participant Roles
+
+## Entity: Agent
+
+An AI runtime or client integration that executes DevSpark prompts.
+
+Fields:
+
+- `key`: Stable integration key from `agents-registry.json`.
+- `name`: Human-readable integration name.
+- `context_file`: Runtime-specific context file path.
+- `release.commands_dir`: Runtime-specific command shim location.
+
+Rules:
+
+- `agent` terminology remains tied to runtime/client integration.
+- Participant role names must not be added to `agents-registry.json`.
+
+## Entity: Prompt
+
+A DevSpark command or workflow instruction surface.
+
+Fields:
+
+- `command_name`: Slash-command name such as `/devspark.plan`.
+- `lifecycle_responsibilities`: Scope checks, script invocation, artifact
+  placement, gates, and handoffs.
+- `delegated_skills`: Optional portable skills used by the prompt.
+
+Rules:
+
+- Prompts own DevSpark lifecycle behavior.
+- Prompts do not become participants.
+
+## Entity: Skill
+
+A reusable portable capability package.
+
+Fields:
+
+- `name`: Skill package name.
+- `description`: Discovery text.
+- `metadata.version`: Skill package version.
+- `resources`: Optional scripts, references, and assets.
+
+Rules:
+
+- Skills provide reusable know-how.
+- Skills do not own participant responsibility metadata unless a future spec
+  defines skill-specific behavior.
+
+## Entity: Participant
+
+A human or AI-filled team member carrying responsibility for work, review,
+approval, or decision capture.
+
+Fields:
+
+- `role`: Responsibility label.
+- `kind`: Lightweight fill type: `human` or `ai`.
+- `name`: Optional display label.
+
+Rules:
+
+- Participant metadata is advisory.
+- Missing participant metadata is valid.
+- Personal names are optional and not recommended in stock examples.
+- Teams own PII handling for any personal names they choose to record.
+
+## Entity: Participant Metadata
+
+Optional YAML frontmatter block carried by spec, plan, and task artifacts.
+
+Example:
+
+```yaml
+participants:
+  owner:
+    kind: human
+  planner:
+    kind: ai
+  implementer:
+    kind: ai
+  reviewer:
+    kind: human
+  critic:
+    kind: ai
+  scribe:
+    kind: ai
+```
+
+Compact examples may use role-to-kind values where readability is better:
+
+```yaml
+participants:
+  owner: human
+  planner: ai
+  reviewer: human
+```
+
+Rules:
+
+- Both compact and expanded examples are advisory unless tests choose one form
+  as the stock template convention.
+- `kind` values in stock examples should be `human` or `ai`.
+- Role names are advisory and not a closed validation set.
+- Commands must not fail when this block is absent.
+
+## State Transitions
+
+Participant metadata has no lifecycle state in this feature.
+
+```text
+absent -> present -> edited -> absent
+```
+
+All states are valid. No command should treat the transition as a workflow gate.

--- a/.documentation/specs/001-participant-roles/gates/analyze.md
+++ b/.documentation/specs/001-participant-roles/gates/analyze.md
@@ -1,0 +1,77 @@
+---
+gate: analyze
+status: pass
+blocking: false
+severity: info
+summary: "Prior wording inconsistencies were repaired; artifacts are aligned for implementation."
+---
+
+# Specification Analysis Report
+
+## Findings
+
+| ID | Category | Severity | Location(s) | Summary | Recommendation |
+| -- | -------- | -------- | ----------- | ------- | -------------- |
+| I1 | Inconsistency | HIGH | `spec.md` User Story 3 acceptance scenario 3; `spec.md` FR-008; `research.md` "Keep command output unchanged"; `tasks.md` T007 | Resolved. User Story 3 now verifies artifact preservation without a dedicated participant output step. | None. |
+| I2 | Inconsistency | HIGH | `spec.md` SC-004; `spec.md` Clarifications; `tasks.md` T028 | Resolved. SC-004 now focuses on fixtures and pre-existing artifacts not requiring participant metadata. | None. |
+
+## Coverage Summary
+
+| Requirement Key | Has Task? | Task IDs | Notes |
+| --------------- | --------- | -------- | ----- |
+| define-agent-runtime | Yes | T006, T008, T009, T011, T012 | Covered by terminology docs and tests. |
+| define-participant-team-member | Yes | T006, T008, T009, T010, T011 | Covered by terminology docs and tests. |
+| define-prompt-command-surface | Yes | T008, T009, T011 | Covered by glossary and template docs. |
+| define-skill-portable-capability | Yes | T008, T009, T011 | Covered by glossary and template docs. |
+| preserve-customization-layers | Yes | T013, T014, T015, T016, T017 | Covered by docs and tests. |
+| add-template-participants-metadata | Yes | T018, T020, T021, T022, T023, T025 | Covered by template edits and tests. |
+| metadata-absence-nonblocking | Yes | T005, T019, T024, T027, T028 | Covered by validation contract and tests. |
+| metadata-artifact-only | Yes | T007, T016, T019, T024 | Covered and aligned with User Story 3. |
+| no-new-inheritance-model | Yes | T007, T014, T015, T016 | Covered by docs and tests. |
+| reserve-agent-term | Yes | T006, T008, T012 | Covered by terminology tests and docs. |
+| advisory-role-set | Yes | T018, T020, T021, T022, T023 | Covered by template metadata examples. |
+| role-to-kind-shape | Yes | T018, T020, T021, T022, T023 | Covered by template metadata examples. |
+
+## Constitution Alignment Issues
+
+No constitution violations found.
+
+## Unmapped Tasks
+
+No unmapped tasks found. All tasks trace to vocabulary, layer preservation,
+optional metadata, or validation requirements.
+
+## Metrics
+
+- Total Requirements: 12
+- Total Tasks: 30
+- Coverage: 100%
+- Ambiguity Count: 0
+- Duplication Count: 0
+- Critical Issues Count: 0
+- High Issues Count: 0
+
+## Shared Review Resolution Contract Output
+
+```yaml
+findings:
+  - finding_id: analyze-I1
+    severity: high
+    description: "User Story 3 acceptance wording allows command output reporting, while FR-008 and research require participant metadata to remain silent and artifact-only."
+    recommended_action: "Edit spec.md User Story 3 acceptance scenario 3 to verify artifact preservation without command output reporting."
+    execution_mode: auto
+    status: resolved
+    outcome: "Updated spec.md User Story 3 acceptance scenario 3 to preserve metadata in artifacts without command output reporting."
+  - finding_id: analyze-I2
+    severity: high
+    description: "SC-004 says no artifact contains participant metadata, but the current feature artifacts already include participants frontmatter."
+    recommended_action: "Edit SC-004 to focus on fixtures and pre-existing artifacts not requiring participant metadata."
+    execution_mode: auto
+    status: resolved
+    outcome: "Updated SC-004 to focus on fixtures and pre-existing artifacts not requiring participant metadata."
+```
+
+## Next Actions
+
+- Proceed to `/devspark.critic`.
+- No analyze-blocking issues remain.

--- a/.documentation/specs/001-participant-roles/gates/critic.md
+++ b/.documentation/specs/001-participant-roles/gates/critic.md
@@ -1,0 +1,131 @@
+```yaml
+gate: critic
+status: pass
+blocking: false
+severity: info
+summary: "All three critic findings were resolved with explicit metadata and strengthened implementation test tasks. No showstoppers or critical risks remain."
+```
+
+## Technical Risk Assessment
+
+**Analysis Date:** 2026-05-31T08:49:15-05:00
+**Resolution Date:** 2026-05-31
+**Scope:** FULL
+**Detected Archetype:** documentation-site
+**Detected Stack:** Markdown documentation + YAML frontmatter + pytest contract tests
+**Context Mode:** brownfield
+**Risk Profile:** internal
+**Risk Posture:** GREEN
+
+### Executive Summary
+
+This feature has low runtime risk because it changes documentation, stock
+templates, and contract tests rather than product execution paths. The prior
+risks around inferred critic metadata, `plan-template.md` frontmatter handling,
+and optional display-label privacy hygiene have been resolved in the spec and
+task list.
+
+No stack/archetype checklists found at `.devspark/risk-checklists/`; analysis
+used the universal failure-mode lens plus the source `templates/risk-checklists/`
+guidance where applicable.
+
+### Findings (source of truth)
+
+```yaml
+findings:
+  - finding_id: critic-001
+    category: documentation
+    archetype_applicable: true
+    location: ".documentation/specs/001-participant-roles/spec.md#frontmatter"
+    description: "The spec frontmatter did not declare archetype, risk_profile, or change_type, which could cause downstream critic runs to rely on fallback assumptions."
+    base_severity: high
+    effective_severity: high
+    recommended_action: "Add explicit critic metadata to the spec frontmatter."
+    execution_mode: selective
+    status: resolved
+    outcome: "Added archetype=documentation-site, risk_profile=internal, and change_type=brownfield to spec.md frontmatter."
+  - finding_id: critic-002
+    category: testing_strategy
+    archetype_applicable: true
+    location: ".documentation/specs/001-participant-roles/tasks.md#T018,.documentation/specs/001-participant-roles/tasks.md#T022,templates/plan-template.md#L1"
+    description: "The current plan template starts directly with an H1, so adding frontmatter requires test coverage that verifies the plan heading remains discoverable after frontmatter is skipped."
+    base_severity: high
+    effective_severity: high
+    recommended_action: "Extend implementation tasks to validate plan-template frontmatter handling and heading discovery."
+    execution_mode: selective
+    status: resolved
+    outcome: "Updated T018 to require a plan-template heading-after-frontmatter assertion and T022 to preserve # Implementation Plan as the first body heading."
+  - finding_id: critic-003
+    category: regulatory_privacy
+    archetype_applicable: true
+    location: ".documentation/specs/001-participant-roles/spec.md#FR-012,.documentation/specs/001-participant-roles/contracts/participant-metadata.md#Optional-Display-Labels,.documentation/specs/001-participant-roles/tasks.md#T007"
+    description: "The optional name field could normalize personal data in stock examples if tests only verified that names are optional."
+    base_severity: medium
+    effective_severity: medium
+    recommended_action: "Make the regression task assert that stock participant examples do not recommend storing personally identifying information."
+    execution_mode: auto
+    status: resolved
+    outcome: "Updated T007 to require assertions that examples do not recommend storing personally identifying information."
+```
+
+### Resolved Findings
+
+| ID | Category | Location | Resolution |
+| -- | -------- | -------- | ---------- |
+| critic-001 | documentation | `spec.md` frontmatter | Added explicit `archetype`, `risk_profile`, and `change_type` metadata. |
+| critic-002 | testing_strategy | `tasks.md` T018/T022; `templates/plan-template.md` line 1 | Strengthened tasks to test plan-template frontmatter handling and preserve the first body heading. |
+| critic-003 | regulatory_privacy | `spec.md` FR-012; metadata contract; `tasks.md` T007 | Strengthened privacy test task so stock examples do not recommend storing PII. |
+
+### Missing Critical Tasks
+
+None. The task list now covers terminology, customization-layer preservation,
+optional metadata, validation, plan-template frontmatter handling, and privacy
+hygiene for optional display labels.
+
+### Residual Assumptions
+
+1. **No runtime behavior is added during implementation** -> If implementation
+   expands beyond documentation, templates, and focused tests, rerun
+   `/devspark.analyze` and `/devspark.critic`.
+2. **Generated plan consumers skip YAML frontmatter correctly** -> T018 now
+   requires this behavior to be tested before implementation is considered
+   complete.
+
+### Dependency Risk Assessment
+
+| Dependency | Concern | Mitigation |
+| ---------- | ------- | ---------- |
+| markdownlint-cli2 | Formatting failures can block docs-only changes late. | Run targeted markdownlint before full-suite validation. |
+| pytest contract tests | Overfitting to one metadata shape can reject valid artifacts or miss parser regressions. | Test metadata absence, the chosen stock-template convention, and plan heading discovery after frontmatter. |
+
+### Estimated Technical Debt at Launch
+
+- **Code Debt:** None expected if no runtime modules are added.
+- **Operational Debt:** Low; participant metadata is silent and advisory.
+- **Documentation Debt:** Low after explicit critic metadata and gate
+  acknowledgements.
+- **Testing Debt:** Low after T018 and T007 hardening.
+
+### Metrics
+
+- Open showstopper count: 0
+- Open critical count: 0
+- Open high count: 0
+- Open medium count: 0
+- Resolved findings: 3
+- Findings by category: documentation 1, testing_strategy 1,
+  regulatory_privacy 1
+- Missing operational tasks: 0
+
+**VERDICT:** PROCEED
+
+**Required Actions Before Implementation:**
+
+None.
+
+**Recommended Risk Mitigations:**
+
+- Keep participant examples compact unless `name` is specifically needed.
+- Avoid real names in all stock participant examples.
+- Re-run `/devspark.analyze` and `/devspark.critic` if implementation expands
+  beyond documentation, templates, and focused tests.

--- a/.documentation/specs/001-participant-roles/plan.md
+++ b/.documentation/specs/001-participant-roles/plan.md
@@ -1,0 +1,174 @@
+---
+participants:
+  owner: human
+  planner: ai
+  implementer: ai
+  reviewer: human
+  critic: ai
+  scribe: ai
+---
+
+# Implementation Plan: Participant Roles
+
+**Branch**: `001-participant-roles` | **Date**: 2026-05-31 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `.documentation/specs/001-participant-roles/spec.md`
+
+## Rationale Summary
+
+### Core Problem
+
+DevSpark needs a durable term for Squad-style team members without overloading
+`agent`, which already means supported AI runtime or client integration.
+
+### Decision Summary
+
+Document `participant` as the team-member concept, keep `agent` reserved for
+runtime integrations, and add optional `participants` YAML frontmatter examples
+to stock spec, plan, and task templates.
+
+### Key Drivers
+
+- Maintain existing prompt, agent, skill, and customization boundaries.
+- Make responsibility context visible in artifacts without changing execution.
+- Preserve backward compatibility for artifacts that omit participant metadata.
+
+### Source Inputs
+
+- [spec.md](spec.md)
+- [research.md](research.md)
+- [data-model.md](data-model.md)
+- [contracts/participant-metadata.md](contracts/participant-metadata.md)
+- DevSpark constitution v1.4.0
+
+### Tradeoffs Considered
+
+- Reusing `agent` for participants was rejected because it conflicts with the
+  current agent registry and supported AI integration docs.
+- Creating a team orchestration engine was rejected because the feature only
+  needs vocabulary, examples, and optional metadata.
+- Participant metadata in YAML frontmatter was selected because it is compact,
+  machine-readable, and optional.
+
+### Architectural Impact
+
+- Markdown documentation and stock templates change.
+- No Python runtime behavior is required.
+- No Bash or PowerShell helper script change is required.
+- No command output should print participant metadata in this phase.
+
+### Reviewer Guidance
+
+Review terminology precision, optional metadata behavior, markdown quality, and
+absence of changes to existing customization layer precedence.
+
+## Summary
+
+This feature updates DevSpark's documentation and templates so users can
+distinguish AI runtime agents from workflow participants. It introduces
+optional `participants` YAML frontmatter examples in the stock spec, plan, and
+tasks templates using advisory role-to-kind metadata.
+
+## Technical Context
+
+**Language/Version**: Markdown documentation and YAML frontmatter examples
+**Primary Dependencies**: markdownlint-cli2, pytest
+**Storage**: N/A
+**Testing**: markdownlint-cli2, pytest, targeted text checks
+**Target Platform**: Any OS supported by DevSpark
+**Project Type**: documentation/templates
+**Performance Goals**: N/A
+**Constraints**: No change to prompt resolution precedence; no new script
+behavior; no required participant metadata
+**Scale/Scope**: README, lifecycle docs, template docs, spec/plan/tasks
+templates, and focused contract tests
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Notes |
+| --------- | ------ | ----- |
+| I. Backward Compatibility | PASS | Missing participant metadata remains valid. |
+| II. Explicit Over Implied | PASS | Participant metadata is explicit when present and silent when absent. |
+| III. Ownership Boundary | PASS | Changes are stock source files and feature artifacts only. |
+| IV. Governance Authority | PASS | No weakening of repo-wide governance or app-scope rules. |
+| V. Simplicity | PASS | Uses optional frontmatter examples, not a new engine or inheritance model. |
+| VI. Platform Parity | PASS | No script changes are planned. |
+| VII. PR Review Artifact Commit Discipline | PASS | No PR review artifact changes are planned. |
+| VIII. Markdown Quality | PASS | Markdownlint will validate changed markdown files. |
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+.documentation/specs/001-participant-roles/
+|-- plan.md
+|-- research.md
+|-- data-model.md
+|-- quickstart.md
+|-- contracts/
+|   `-- participant-metadata.md
+|-- checklists/
+|   `-- requirements.md
+`-- tasks.md
+```
+
+### Source Code (repository root)
+
+```text
+README.md
+.documentation/
+|-- implementation-lifecycle.md
+`-- constitution-guide.md
+templates/
+|-- README.md
+|-- spec-template.md
+|-- quick-spec-template.md
+|-- plan-template.md
+|-- tasks-template.md
+`-- spec-validation-contract.md
+tests/
+`-- test_participant_metadata_contract.py
+```
+
+**Structure Decision**: This is a documentation and template feature. The
+implementation should avoid new runtime modules unless tests show that existing
+contract coverage cannot express the required guarantees.
+
+## Phase 0: Research
+
+Research is complete in [research.md](research.md).
+
+Key decisions:
+
+- Use `participant` for team-member concepts.
+- Use optional YAML frontmatter, not visible sections.
+- Use advisory roles and role-to-kind metadata.
+- Allow optional `name` but do not recommend storing personal data.
+- Keep metadata silent in command output.
+
+## Phase 1: Design & Contracts
+
+Design artifacts:
+
+- [data-model.md](data-model.md)
+- [contracts/participant-metadata.md](contracts/participant-metadata.md)
+- [quickstart.md](quickstart.md)
+
+Implementation should update documentation and templates first, then add focused
+tests that prevent regressions in terminology and metadata optionality.
+
+## Constitution Check Re-evaluation
+
+| Principle | Status | Notes |
+| --------- | ------ | ----- |
+| Backward Compatibility | PASS | Existing artifacts and tests without participants remain supported. |
+| Explicit Over Implied | PASS | Metadata shape is explicit and advisory. |
+| Ownership Boundary | PASS | No `.documentation/` installation or upgrade behavior changes. |
+| Simplicity | PASS | No new participant resolution engine. |
+| Platform Parity | PASS | No script changes. |
+
+## Complexity Tracking
+
+No constitution violations require justification.

--- a/.documentation/specs/001-participant-roles/quickstart.md
+++ b/.documentation/specs/001-participant-roles/quickstart.md
@@ -44,3 +44,14 @@ Run the full suite before completion:
 - Tests pass with no fixture requiring participant metadata.
 - Markdown lint reports zero errors for changed markdown.
 - Existing prompt and script resolution documentation remains unchanged.
+
+## Final Validation Notes
+
+Validated on 2026-05-31 with the planned commands:
+
+- `npx markdownlint-cli2 "README.md" ".documentation/**/*.md" "templates/**/*.md"`
+- `.\.venv\Scripts\python -m pytest -q tests/test_participant_metadata_contract.py`
+- `.\.venv\Scripts\python -m pytest -q`
+- `git diff --check`
+
+All commands completed successfully.

--- a/.documentation/specs/001-participant-roles/quickstart.md
+++ b/.documentation/specs/001-participant-roles/quickstart.md
@@ -1,0 +1,46 @@
+# Quickstart: Participant Roles
+
+## Goal
+
+Validate that DevSpark documents participants without changing agent runtime
+semantics or existing customization layers.
+
+## Manual Verification
+
+1. Read `README.md`.
+2. Confirm `agent` still means supported AI runtime/client integration.
+3. Confirm `participant` is introduced as a human or AI-filled team member.
+4. Read `.documentation/implementation-lifecycle.md`.
+5. Confirm the lifecycle explains that participant concepts do not change
+   existing customization layers.
+6. Inspect `templates/spec-template.md`, `templates/quick-spec-template.md`,
+   `templates/plan-template.md`, and `templates/tasks-template.md`.
+7. Confirm each template has optional `participants` YAML frontmatter metadata.
+8. Confirm no command output instruction requires printing participant metadata.
+
+## Automated Verification
+
+Run markdown lint on changed markdown:
+
+```powershell
+npx markdownlint-cli2 "README.md" ".documentation/**/*.md" "templates/**/*.md"
+```
+
+Run focused tests:
+
+```powershell
+.\.venv\Scripts\python -m pytest -q tests/test_participant_metadata_contract.py
+.\.venv\Scripts\python -m pytest -q tests/test_skill_contract.py tests/test_workflow_schema_contract.py
+```
+
+Run the full suite before completion:
+
+```powershell
+.\.venv\Scripts\python -m pytest -q
+```
+
+## Expected Result
+
+- Tests pass with no fixture requiring participant metadata.
+- Markdown lint reports zero errors for changed markdown.
+- Existing prompt and script resolution documentation remains unchanged.

--- a/.documentation/specs/001-participant-roles/research.md
+++ b/.documentation/specs/001-participant-roles/research.md
@@ -1,0 +1,83 @@
+# Research: Participant Roles
+
+## Decision: Reserve `agent` for AI runtime/client integrations
+
+**Rationale**: DevSpark already has `agents-registry.json` and user-facing docs
+that use `agent` for supported AI integrations such as Codex, Claude, Copilot,
+Cursor, and Gemini. Reusing the same word for team members would make command
+shims, agent context files, and participant responsibility metadata ambiguous.
+
+**Alternatives considered**:
+
+- Reuse `agent` for team members. Rejected because it conflicts with existing
+  DevSpark terminology.
+- Rename existing AI integrations. Rejected because it would create unnecessary
+  migration and documentation churn.
+
+## Decision: Use `participant` for human or AI-filled team members
+
+**Rationale**: `Participant` works for humans and AI-filled roles without
+implying a specific runtime, identity, or execution engine. It also avoids
+overloading `role`, which is better used for responsibility labels.
+
+**Alternatives considered**:
+
+- `Role`: too narrow for a concrete team member.
+- `Contributor`: already has common source-control meaning.
+- `Worker`: implies execution behavior that is out of scope.
+
+## Decision: Store optional metadata in YAML frontmatter
+
+**Rationale**: Frontmatter is already used by DevSpark specs and prompts for
+machine-readable metadata. Optional YAML metadata can be ignored by existing
+commands and tests while remaining discoverable for future tooling.
+
+**Alternatives considered**:
+
+- Visible `## Participants` section. Rejected because this feature should keep
+  participant context silent/artifact-only in command output.
+- No canonical location. Rejected because templates would drift.
+
+## Decision: Use advisory canonical roles
+
+**Rationale**: A small role set gives examples consistent names without
+creating validation behavior. The selected roles cover responsibility,
+planning, implementation, review, adversarial review, and decision capture.
+
+**Selected advisory roles**:
+
+- `owner`
+- `planner`
+- `implementer`
+- `reviewer`
+- `critic`
+- `scribe`
+
+**Alternatives considered**:
+
+- Minimal role set only. Rejected because `critic` and `scribe` are distinct
+  DevSpark workflow responsibilities.
+- Closed validation set. Rejected because teams may need local role names.
+
+## Decision: Use simple role-to-kind values with optional names
+
+**Rationale**: A role-to-kind map is enough for examples and avoids identity
+semantics. The optional `name` field can support local teams that want labels,
+but DevSpark should not require or recommend personal data.
+
+**Alternatives considered**:
+
+- Role-to-label only. Rejected because it does not distinguish human vs AI.
+- Required objects with names. Rejected because it would create unnecessary PII
+  pressure.
+
+## Decision: Keep command output unchanged
+
+**Rationale**: The clarified spec says participant metadata is silent and
+artifact-only. Commands may preserve or ignore it, but they should not add a
+dedicated participant printout step in this phase.
+
+**Alternatives considered**:
+
+- Print participant summaries in command reports. Rejected because it creates
+  behavior before participants have workflow semantics.

--- a/.documentation/specs/001-participant-roles/spec.md
+++ b/.documentation/specs/001-participant-roles/spec.md
@@ -1,0 +1,258 @@
+---
+classification: full-spec
+risk_level: medium
+target_workflow: specify-full
+required_artifacts: spec, plan, tasks
+recommended_next_step: plan
+required_gates: checklist, analyze, critic
+---
+
+# Feature Specification: Participant Roles
+
+**Feature Branch**: `001-participant-roles`
+**Created**: 2026-05-31
+**Status**: Draft
+**Input**: User description: "Document participant terminology and optional participant metadata for DevSpark phase 1 and phase 2, preserving existing customization layers and keeping agent reserved for AI runtimes."
+
+## Rationale Summary
+
+### Core Problem
+
+DevSpark currently uses `agent` clearly for supported AI runtimes and
+integrations, but discussion around Squad-style team concepts introduces a
+different meaning: a human or AI-filled team member. Without a distinct term,
+future documentation and workflow metadata could blur runtime integration,
+responsibility assignment, prompts, and skills.
+
+### Decision Summary
+
+Use `participant` for human or AI-filled team members and keep `agent` reserved
+for AI runtime/client integrations. Document the vocabulary first, then add
+optional participant metadata to lifecycle templates as advisory context only.
+
+### Key Drivers
+
+- Preserve DevSpark's existing prompt, agent, and skill boundaries.
+- Prevent Squad-inspired team concepts from changing DevSpark's stable
+  default, team, and individual customization process.
+- Improve auditability by making ownership and review responsibilities visible
+  without creating a parallel orchestration system.
+
+### Source Inputs
+
+- User decision to use `participants` for team members.
+- DevSpark constitution principles for backward compatibility, explicit scope,
+  ownership boundaries, simplicity, and platform parity.
+- Existing README language that defines agents as supported AI integrations and
+  skills as portable capability packages.
+- Existing spec, plan, and task templates that can carry optional advisory
+  metadata without changing command execution.
+
+### Tradeoffs Considered
+
+- Option A: Reuse `agent` for team members. Not chosen because it conflicts
+  with `agents-registry.json` and supported AI runtime terminology.
+- Option B: Introduce a full team orchestration model. Not chosen because it
+  adds complexity before DevSpark has a proven need for execution behavior.
+- Selected: Define `participant` as a responsibility-bearing team member and
+  add optional metadata in templates without hard validation or new layering.
+
+### Architectural Impact
+
+- Documentation gains a stable glossary for prompt, agent, skill, participant,
+  and role.
+- Spec, plan, and task templates may include optional `participants` YAML
+  frontmatter metadata.
+- Existing command resolution, customization layers, script resolution, and
+  agent registry behavior remain unchanged.
+- Missing participant metadata remains valid and must not block workflows.
+
+### Reviewer Guidance
+
+Reviewers should focus on terminology precision, preservation of existing
+customization layers, warning-only treatment of optional metadata, and avoiding
+new inheritance or orchestration behavior.
+
+### Assumptions
+
+- This feature covers phase 1 and phase 2 only; reviewer lockout, scribe
+  harvesting, or participant-based routing behavior is deferred.
+- Existing personal, team, and stock prompt resolution remains unchanged.
+- Existing team and stock script resolution remains unchanged.
+- Participant metadata is advisory until a later approved spec defines behavior
+  that consumes it.
+
+## Clarifications
+
+### Session 2026-05-31
+
+- Q: Where should optional participant context live in generated artifacts? → A: Optional `participants` YAML frontmatter in spec, plan, and tasks templates.
+- Q: Should DevSpark define a canonical participant role set for examples? → A: Use advisory canonical roles: `owner`, `planner`, `implementer`, `reviewer`, `critic`, `scribe`.
+- Q: What shape should the optional `participants` YAML metadata use? → A: Map each role to a simple kind value such as `human` or `ai`.
+- Q: May participant metadata include a display name field alongside role and kind? → A: Yes — an optional `name:` field is allowed; it is advisory and teams own PII handling for any personal data they choose to record.
+- Q: Should commands surface participant metadata visibly in output when present? → A: No — metadata is silent / artifact-only; commands do not add a dedicated participant printout step.
+- Q: How should SC-004 be validated at acceptance time? → A: SC-004 is satisfied when the existing `pytest` suite passes green with no participant metadata present in any fixture.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Understand Core Vocabulary (Priority: P1)
+
+As a DevSpark user, I want documentation to distinguish prompts, agents, skills,
+participants, and roles so that I can discuss team workflows without confusing
+runtime integrations with responsibility assignments.
+
+**Why this priority**: Clear vocabulary is the foundation for every later
+participant-related change.
+
+**Independent Test**: Read the updated documentation and verify each term has a
+single DevSpark-specific definition with examples.
+
+**Acceptance Scenarios**:
+
+1. **Given** a user reads the DevSpark lifecycle or glossary documentation,
+   **When** they look up `agent`, **Then** it is defined as an AI runtime or
+   client integration such as Codex, Claude, Copilot, Cursor, or Gemini.
+2. **Given** a user reads the same documentation, **When** they look up
+   `participant`, **Then** it is defined as a human or AI-filled team member
+   responsible for work, review, approval, or decision capture.
+3. **Given** a user reads the glossary, **When** they compare `prompt` and
+   `skill`, **Then** prompts are described as workflow command surfaces and
+   skills as reusable portable capability packages.
+
+---
+
+### User Story 2 - Preserve Existing Customization Layers (Priority: P2)
+
+As a DevSpark maintainer, I want participant guidance to explicitly preserve
+the current default, team, and individual customization process so that new
+concepts do not introduce a competing layer model.
+
+**Why this priority**: The existing layer process is a core DevSpark value and
+must remain stable while participant terminology is introduced.
+
+**Independent Test**: Inspect changed docs and templates and confirm they do
+not rename, relocate, reorder, or replace the existing customization layers.
+
+**Acceptance Scenarios**:
+
+1. **Given** a user reads participant documentation, **When** customization is
+   discussed, **Then** the documentation states that participant concepts must
+   use DevSpark's existing customization process.
+2. **Given** a maintainer reviews the implementation, **When** they inspect
+   prompt and script resolution documentation, **Then** the existing precedence
+   remains unchanged.
+3. **Given** a team has existing personal or team command overrides, **When**
+   DevSpark participant documentation is added, **Then** those overrides remain
+   valid and are not migrated.
+
+---
+
+### User Story 3 - Add Optional Participant Metadata (Priority: P3)
+
+As a DevSpark author, I want spec, plan, and task artifacts to have an optional
+place to record participant context so responsibility is visible without making
+the metadata mandatory.
+
+**Why this priority**: Optional metadata improves auditability while preserving
+backward compatibility for existing artifacts.
+
+**Independent Test**: Generate or inspect stock templates and confirm they show
+optional participant examples while validation guidance treats absence as valid.
+
+**Acceptance Scenarios**:
+
+1. **Given** a new spec is created from the stock template, **When** optional
+   participant metadata is present, **Then** it identifies responsibility
+   context such as owner, planner, implementer, reviewer, critic, or scribe.
+2. **Given** an existing spec lacks participant metadata, **When** DevSpark
+   validation or review guidance evaluates it, **Then** the missing metadata is
+   at most a warning or recommendation and not a failure.
+3. **Given** participant metadata is present in plan or task artifacts, **When**
+   commands summarize artifact context, **Then** they may report it as advisory
+   responsibility context without changing execution.
+
+### Edge Cases
+
+- Existing artifacts without participant metadata must remain valid.
+- Team or personal prompt overrides that do not know about participants must
+  continue to resolve normally.
+- Participant metadata must not be confused with `agents-registry.json`.
+- Human names may be omitted; role labels alone must be acceptable.
+- Multi-app repositories must not gain a new scope resolution mechanism from
+  participant metadata.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: DevSpark documentation MUST define `agent` as an AI runtime or
+  client integration and MUST NOT redefine it as a team member.
+- **FR-002**: DevSpark documentation MUST define `participant` as a human or
+  AI-filled team member that carries responsibility in a workflow.
+- **FR-003**: DevSpark documentation MUST define `prompt` as a command or
+  workflow instruction surface that orchestrates DevSpark lifecycle behavior.
+- **FR-004**: DevSpark documentation MUST define `skill` as a reusable portable
+  capability package that can be delegated to by prompts.
+- **FR-005**: Participant guidance MUST state that DevSpark's existing
+  customization layers and precedence are unchanged.
+- **FR-006**: Stock spec, plan, and task templates SHOULD include optional
+  `participants` YAML frontmatter metadata.
+- **FR-007**: Missing participant metadata MUST NOT fail the shared
+  specification validation contract, task format expectations, or plan
+  generation guidance.
+- **FR-008**: Commands that mention participant metadata MUST describe it as
+  advisory responsibility context unless a later approved spec defines
+  executable behavior. Commands MUST NOT add a dedicated participant printout
+  step; participant metadata is silent / artifact-only and is not surfaced in
+  command output in this phase.
+- **FR-009**: Participant metadata MUST NOT introduce a new upstream,
+  inheritance, or override model.
+- **FR-010**: Documentation updates MUST use `participant` for team-member
+  concepts and reserve `agent` for supported AI integrations or agent-specific
+  runtime files.
+- **FR-011**: Participant examples SHOULD use the advisory canonical roles
+  `owner`, `planner`, `implementer`, `reviewer`, `critic`, and `scribe`; other
+  role names MUST remain valid unless a later approved spec adds validation.
+- **FR-012**: Participant metadata examples SHOULD use a simple role-to-kind
+  mapping, such as `owner: human`, `planner: ai`, and `reviewer: human`.
+  An optional `name:` field MAY appear alongside `kind:` as a display label;
+  it is advisory and MUST NOT be required. Teams that include personal names
+  in `name:` are responsible for their own PII handling; DevSpark documentation
+  MUST NOT recommend storing personally identifying information in the field.
+
+### Key Entities *(include if feature involves data)*
+
+- **Agent**: A supported AI runtime or client integration that executes
+  DevSpark prompts.
+- **Prompt**: A DevSpark command or workflow instruction that owns lifecycle
+  orchestration.
+- **Skill**: A portable capability package that owns reusable task knowledge.
+- **Participant**: A human or AI-filled team member carrying responsibility for
+  work, review, approval, or decision capture.
+- **Role**: A responsibility label a participant may hold, such as owner,
+  planner, implementer, reviewer, critic, or scribe. These role names are
+  advisory examples, not a closed validation set.
+- **Participant Kind**: A lightweight value describing whether a role is filled
+  by a `human` or `ai` participant. It is advisory metadata, not an identity
+  record.
+- **Participant Name**: An optional display label that MAY accompany a
+  participant entry. It is advisory only. Teams that populate it with personal
+  names are responsible for their own PII handling; DevSpark does not validate,
+  process, or require this field.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: The updated documentation contains definitions for all five
+  vocabulary terms: prompt, agent, skill, participant, and role.
+- **SC-002**: At least one lifecycle-facing document explains that participant
+  concepts do not change DevSpark's existing customization layers.
+- **SC-003**: The stock spec, plan, and task templates each include optional
+  `participants` YAML frontmatter metadata.
+- **SC-004**: The existing `pytest` suite passes green (`pytest` exits 0) on a
+  checkout where no artifact contains participant metadata, confirming that
+  prompt resolution, skill validation, workflow validation, and documentation
+  audit are unaffected by this feature.
+- **SC-005**: A text search for new team-member guidance shows `participant`
+  usage instead of redefining `agent` outside existing AI-runtime contexts.

--- a/.documentation/specs/001-participant-roles/spec.md
+++ b/.documentation/specs/001-participant-roles/spec.md
@@ -14,7 +14,7 @@ required_gates: checklist, analyze, critic
 
 **Feature Branch**: `001-participant-roles`
 **Created**: 2026-05-31
-**Status**: Draft
+**Status**: Complete
 **Input**: User description: "Document participant terminology and optional participant metadata for DevSpark phase 1 and phase 2, preserving existing customization layers and keeping agent reserved for AI runtimes."
 
 ## Rationale Summary
@@ -98,7 +98,7 @@ new inheritance or orchestration behavior.
 
 ## User Scenarios & Testing *(mandatory)*
 
-### User Story 1 - Understand Core Vocabulary (Priority: P1)
+### User Story 1 - Understand Core Vocabulary (Priority: P1) ✅ Complete
 
 As a DevSpark user, I want documentation to distinguish prompts, agents, skills,
 participants, and roles so that I can discuss team workflows without confusing
@@ -124,7 +124,7 @@ single DevSpark-specific definition with examples.
 
 ---
 
-### User Story 2 - Preserve Existing Customization Layers (Priority: P2)
+### User Story 2 - Preserve Existing Customization Layers (Priority: P2) ✅ Complete
 
 As a DevSpark maintainer, I want participant guidance to explicitly preserve
 the current default, team, and individual customization process so that new
@@ -150,7 +150,7 @@ not rename, relocate, reorder, or replace the existing customization layers.
 
 ---
 
-### User Story 3 - Add Optional Participant Metadata (Priority: P3)
+### User Story 3 - Add Optional Participant Metadata (Priority: P3) ✅ Complete
 
 As a DevSpark author, I want spec, plan, and task artifacts to have an optional
 place to record participant context so responsibility is visible without making

--- a/.documentation/specs/001-participant-roles/spec.md
+++ b/.documentation/specs/001-participant-roles/spec.md
@@ -1,6 +1,9 @@
 ---
 classification: full-spec
 risk_level: medium
+risk_profile: internal
+change_type: brownfield
+archetype: documentation-site
 target_workflow: specify-full
 required_artifacts: spec, plan, tasks
 recommended_next_step: plan
@@ -168,8 +171,9 @@ optional participant examples while validation guidance treats absence as valid.
    validation or review guidance evaluates it, **Then** the missing metadata is
    at most a warning or recommendation and not a failure.
 3. **Given** participant metadata is present in plan or task artifacts, **When**
-   commands summarize artifact context, **Then** they may report it as advisory
-   responsibility context without changing execution.
+   commands run or summarize artifact context, **Then** the metadata remains
+   preserved in artifacts and is not surfaced through a dedicated participant
+   printout step.
 
 ### Edge Cases
 
@@ -250,9 +254,9 @@ optional participant examples while validation guidance treats absence as valid.
   concepts do not change DevSpark's existing customization layers.
 - **SC-003**: The stock spec, plan, and task templates each include optional
   `participants` YAML frontmatter metadata.
-- **SC-004**: The existing `pytest` suite passes green (`pytest` exits 0) on a
-  checkout where no artifact contains participant metadata, confirming that
-  prompt resolution, skill validation, workflow validation, and documentation
-  audit are unaffected by this feature.
+- **SC-004**: The existing `pytest` suite passes green (`pytest` exits 0)
+  without requiring participant metadata in fixtures or pre-existing artifacts,
+  confirming that prompt resolution, skill validation, workflow validation, and
+  documentation audit are unaffected by this feature.
 - **SC-005**: A text search for new team-member guidance shows `participant`
   usage instead of redefining `agent` outside existing AI-runtime contexts.

--- a/.documentation/specs/001-participant-roles/tasks.md
+++ b/.documentation/specs/001-participant-roles/tasks.md
@@ -62,9 +62,11 @@ customization layer precedence.
 **Purpose**: Establish test and documentation targets before changing product
 content.
 
-- [ ] T001 Review participant metadata contract in `.documentation/specs/001-participant-roles/contracts/participant-metadata.md`
-- [ ] T002 Review current terminology references in `README.md`, `.documentation/implementation-lifecycle.md`, `.documentation/constitution-guide.md`, and `templates/README.md`
-- [ ] T003 [P] Inspect current stock template frontmatter in `templates/spec-template.md`, `templates/quick-spec-template.md`, `templates/plan-template.md`, and `templates/tasks-template.md`
+- [X] T001 Review participant metadata contract in `.documentation/specs/001-participant-roles/contracts/participant-metadata.md`
+- [X] T002 Review current terminology references in `README.md`, `.documentation/implementation-lifecycle.md`, `.documentation/constitution-guide.md`, and `templates/README.md`
+- [X] T003 [P] Inspect current stock template frontmatter in `templates/spec-template.md`, `templates/quick-spec-template.md`, `templates/plan-template.md`, and `templates/tasks-template.md`
+
+**Checkpoint**: Phase complete - 2026-05-31
 
 ---
 
@@ -73,10 +75,12 @@ content.
 **Purpose**: Add regression tests and shared wording before updating individual
 user-story surfaces.
 
-- [ ] T004 Create participant terminology and metadata contract tests in `tests/test_participant_metadata_contract.py`
-- [ ] T005 Add assertions in `tests/test_participant_metadata_contract.py` that existing artifacts without `participants` metadata remain valid by checking representative fixture/spec/template parsing does not require the field
-- [ ] T006 Add assertions in `tests/test_participant_metadata_contract.py` that stock docs reserve `agent` for AI runtime/client integrations and use `participant` for team-member concepts
-- [ ] T007 Add assertions in `tests/test_participant_metadata_contract.py` that participant metadata examples do not require personal names, do not recommend storing personally identifying information, and do not mention participant routing, inheritance, or command output behavior
+- [X] T004 Create participant terminology and metadata contract tests in `tests/test_participant_metadata_contract.py`
+- [X] T005 Add assertions in `tests/test_participant_metadata_contract.py` that existing artifacts without `participants` metadata remain valid by checking representative fixture/spec/template parsing does not require the field
+- [X] T006 Add assertions in `tests/test_participant_metadata_contract.py` that stock docs reserve `agent` for AI runtime/client integrations and use `participant` for team-member concepts
+- [X] T007 Add assertions in `tests/test_participant_metadata_contract.py` that participant metadata examples do not require personal names, do not recommend storing personally identifying information, and do not mention participant routing, inheritance, or command output behavior
+
+**Checkpoint**: Phase complete - 2026-05-31
 
 **Checkpoint**: Contract tests define the expected vocabulary and optional
 metadata behavior before product files are edited.
@@ -93,14 +97,16 @@ in `tests/test_participant_metadata_contract.py`.
 
 ### Tests for User Story 1
 
-- [ ] T008 [P] [US1] Add test coverage for required glossary terms in `tests/test_participant_metadata_contract.py`
+- [X] T008 [P] [US1] Add test coverage for required glossary terms in `tests/test_participant_metadata_contract.py`
 
 ### Implementation for User Story 1
 
-- [ ] T009 [US1] Add a glossary section defining `prompt`, `agent`, `skill`, `participant`, and `role` in `README.md`
-- [ ] T010 [US1] Add lifecycle terminology guidance explaining participant responsibilities in `.documentation/implementation-lifecycle.md`
-- [ ] T011 [US1] Update template documentation to distinguish prompts, agents, skills, and participants in `templates/README.md`
-- [ ] T012 [US1] Ensure new team-member guidance uses `participant` instead of redefining `agent` in `README.md`, `.documentation/implementation-lifecycle.md`, and `templates/README.md`
+- [X] T009 [US1] Add a glossary section defining `prompt`, `agent`, `skill`, `participant`, and `role` in `README.md`
+- [X] T010 [US1] Add lifecycle terminology guidance explaining participant responsibilities in `.documentation/implementation-lifecycle.md`
+- [X] T011 [US1] Update template documentation to distinguish prompts, agents, skills, and participants in `templates/README.md`
+- [X] T012 [US1] Ensure new team-member guidance uses `participant` instead of redefining `agent` in `README.md`, `.documentation/implementation-lifecycle.md`, and `templates/README.md`
+
+**Checkpoint**: Phase complete - 2026-05-31
 
 **Checkpoint**: Core vocabulary is documented and independently reviewable.
 
@@ -117,14 +123,16 @@ layer model.
 
 ### Tests for User Story 2
 
-- [ ] T013 [P] [US2] Add test assertions that `README.md` still documents the existing 3-tier prompt resolution and 2-tier script resolution in `tests/test_participant_metadata_contract.py`
-- [ ] T014 [P] [US2] Add test assertions that participant documentation does not introduce upstream inheritance or a participant override model in `tests/test_participant_metadata_contract.py`
+- [X] T013 [P] [US2] Add test assertions that `README.md` still documents the existing 3-tier prompt resolution and 2-tier script resolution in `tests/test_participant_metadata_contract.py`
+- [X] T014 [P] [US2] Add test assertions that participant documentation does not introduce upstream inheritance or a participant override model in `tests/test_participant_metadata_contract.py`
 
 ### Implementation for User Story 2
 
-- [ ] T015 [US2] Update `README.md` participant guidance to state that existing customization layers and precedence are unchanged
-- [ ] T016 [US2] Update `.documentation/implementation-lifecycle.md` to state that participant metadata is advisory and does not affect command, prompt, or script resolution
-- [ ] T017 [US2] Update `.documentation/constitution-guide.md` only if needed to clarify that participants do not weaken constitution authority or app-level governance
+- [X] T015 [US2] Update `README.md` participant guidance to state that existing customization layers and precedence are unchanged
+- [X] T016 [US2] Update `.documentation/implementation-lifecycle.md` to state that participant metadata is advisory and does not affect command, prompt, or script resolution
+- [X] T017 [US2] Update `.documentation/constitution-guide.md` only if needed to clarify that participants do not weaken constitution authority or app-level governance
+
+**Checkpoint**: Phase complete - 2026-05-31
 
 **Checkpoint**: Participant docs preserve DevSpark's current customization
 process.
@@ -141,17 +149,19 @@ verify metadata is optional and artifact-only.
 
 ### Tests for User Story 3
 
-- [ ] T018 [P] [US3] Add test assertions that `templates/spec-template.md`, `templates/quick-spec-template.md`, `templates/plan-template.md`, and `templates/tasks-template.md` include optional `participants` YAML frontmatter, and that `templates/plan-template.md` still exposes its `# Implementation Plan` heading after frontmatter is skipped, in `tests/test_participant_metadata_contract.py`
-- [ ] T019 [P] [US3] Add test assertions that `templates/spec-validation-contract.md` documents optional participant metadata as advisory and non-blocking in `tests/test_participant_metadata_contract.py`
+- [X] T018 [P] [US3] Add test assertions that `templates/spec-template.md`, `templates/quick-spec-template.md`, `templates/plan-template.md`, and `templates/tasks-template.md` include optional `participants` YAML frontmatter, and that `templates/plan-template.md` still exposes its `# Implementation Plan` heading after frontmatter is skipped, in `tests/test_participant_metadata_contract.py`
+- [X] T019 [P] [US3] Add test assertions that `templates/spec-validation-contract.md` documents optional participant metadata as advisory and non-blocking in `tests/test_participant_metadata_contract.py`
 
 ### Implementation for User Story 3
 
-- [ ] T020 [US3] Add optional `participants` YAML frontmatter examples to `templates/spec-template.md`
-- [ ] T021 [US3] Add optional `participants` YAML frontmatter examples to `templates/quick-spec-template.md`
-- [ ] T022 [US3] Add optional `participants` YAML frontmatter examples to `templates/plan-template.md` while preserving `# Implementation Plan` as the first body heading
-- [ ] T023 [US3] Add optional `participants` YAML frontmatter examples to `templates/tasks-template.md`
-- [ ] T024 [US3] Update `templates/spec-validation-contract.md` to state that `participants` is optional advisory metadata and absence must not fail validation
-- [ ] T025 [US3] Update `templates/README.md` helper template documentation to mention optional participant metadata in stock lifecycle templates
+- [X] T020 [US3] Add optional `participants` YAML frontmatter examples to `templates/spec-template.md`
+- [X] T021 [US3] Add optional `participants` YAML frontmatter examples to `templates/quick-spec-template.md`
+- [X] T022 [US3] Add optional `participants` YAML frontmatter examples to `templates/plan-template.md` while preserving `# Implementation Plan` as the first body heading
+- [X] T023 [US3] Add optional `participants` YAML frontmatter examples to `templates/tasks-template.md`
+- [X] T024 [US3] Update `templates/spec-validation-contract.md` to state that `participants` is optional advisory metadata and absence must not fail validation
+- [X] T025 [US3] Update `templates/README.md` helper template documentation to mention optional participant metadata in stock lifecycle templates
+
+**Checkpoint**: Phase complete - 2026-05-31
 
 **Checkpoint**: Stock templates carry optional participant metadata examples and
 existing artifacts without the metadata remain valid.
@@ -163,11 +173,13 @@ existing artifacts without the metadata remain valid.
 **Purpose**: Validate the full documentation/template change and prepare it for
 review.
 
-- [ ] T026 [P] Run `npx markdownlint-cli2 "README.md" ".documentation/**/*.md" "templates/**/*.md"` and fix markdown issues in changed files
-- [ ] T027 Run `.\.venv\Scripts\python -m pytest -q tests/test_participant_metadata_contract.py` and fix failures
-- [ ] T028 Run `.\.venv\Scripts\python -m pytest -q` and confirm existing test suite passes without participant metadata in fixtures
-- [ ] T029 Run `git diff --check` and fix whitespace or line-ending issues in changed files
-- [ ] T030 Update `.documentation/specs/001-participant-roles/quickstart.md` with final validation notes if commands differ from the planned verification steps
+- [X] T026 [P] Run `npx markdownlint-cli2 "README.md" ".documentation/**/*.md" "templates/**/*.md"` and fix markdown issues in changed files
+- [X] T027 Run `.\.venv\Scripts\python -m pytest -q tests/test_participant_metadata_contract.py` and fix failures
+- [X] T028 Run `.\.venv\Scripts\python -m pytest -q` and confirm existing test suite passes without participant metadata in fixtures
+- [X] T029 Run `git diff --check` and fix whitespace or line-ending issues in changed files
+- [X] T030 Update `.documentation/specs/001-participant-roles/quickstart.md` with final validation notes if commands differ from the planned verification steps
+
+**Checkpoint**: Phase complete - 2026-05-31
 
 ---
 

--- a/.documentation/specs/001-participant-roles/tasks.md
+++ b/.documentation/specs/001-participant-roles/tasks.md
@@ -1,0 +1,250 @@
+---
+participants:
+  owner: human
+  planner: ai
+  implementer: ai
+  reviewer: human
+  critic: ai
+  scribe: ai
+---
+
+# Tasks: Participant Roles
+
+**Input**: Design documents from `.documentation/specs/001-participant-roles/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/
+
+**Tests**: Include focused contract tests because the spec requires existing
+validation behavior to remain green without participant metadata.
+
+**Organization**: Tasks are grouped by user story to enable independent
+implementation and testing of each story.
+
+## Rationale Summary
+
+### Core Problem
+
+DevSpark needs to introduce Squad-style team members without overloading
+`agent`, which already means supported AI runtime or client integration.
+
+### Decision Summary
+
+Use `participant` for human or AI-filled team members, keep `agent` reserved
+for AI runtimes, and add optional `participants` YAML frontmatter examples to
+stock lifecycle templates.
+
+### Key Drivers
+
+- Preserve existing prompt, agent, skill, and customization boundaries.
+- Keep participant metadata optional, advisory, and artifact-only.
+- Avoid new runtime behavior, routing, inheritance, or validation failures.
+
+### Reviewer Guidance
+
+Review terminology precision, template metadata optionality, test coverage for
+non-blocking metadata, markdown quality, and preservation of existing
+customization layer precedence.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel because it touches different files or has no
+  dependency on incomplete tasks.
+- **[Story]**: Which user story this task belongs to, such as US1, US2, or US3.
+- Include exact file paths in descriptions.
+
+## Path Conventions
+
+- Documentation files live under repository root or `.documentation/`.
+- Stock templates live under `templates/`.
+- Contract tests live under `tests/`.
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Establish test and documentation targets before changing product
+content.
+
+- [ ] T001 Review participant metadata contract in `.documentation/specs/001-participant-roles/contracts/participant-metadata.md`
+- [ ] T002 Review current terminology references in `README.md`, `.documentation/implementation-lifecycle.md`, `.documentation/constitution-guide.md`, and `templates/README.md`
+- [ ] T003 [P] Inspect current stock template frontmatter in `templates/spec-template.md`, `templates/quick-spec-template.md`, `templates/plan-template.md`, and `templates/tasks-template.md`
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Add regression tests and shared wording before updating individual
+user-story surfaces.
+
+- [ ] T004 Create participant terminology and metadata contract tests in `tests/test_participant_metadata_contract.py`
+- [ ] T005 Add assertions in `tests/test_participant_metadata_contract.py` that existing artifacts without `participants` metadata remain valid by checking representative fixture/spec/template parsing does not require the field
+- [ ] T006 Add assertions in `tests/test_participant_metadata_contract.py` that stock docs reserve `agent` for AI runtime/client integrations and use `participant` for team-member concepts
+- [ ] T007 Add assertions in `tests/test_participant_metadata_contract.py` that participant metadata examples do not require personal names, do not recommend storing personally identifying information, and do not mention participant routing, inheritance, or command output behavior
+
+**Checkpoint**: Contract tests define the expected vocabulary and optional
+metadata behavior before product files are edited.
+
+---
+
+## Phase 3: User Story 1 - Understand Core Vocabulary (Priority: P1)
+
+**Goal**: Users can distinguish prompt, agent, skill, participant, and role in
+DevSpark documentation.
+
+**Independent Test**: Read updated documentation and run terminology assertions
+in `tests/test_participant_metadata_contract.py`.
+
+### Tests for User Story 1
+
+- [ ] T008 [P] [US1] Add test coverage for required glossary terms in `tests/test_participant_metadata_contract.py`
+
+### Implementation for User Story 1
+
+- [ ] T009 [US1] Add a glossary section defining `prompt`, `agent`, `skill`, `participant`, and `role` in `README.md`
+- [ ] T010 [US1] Add lifecycle terminology guidance explaining participant responsibilities in `.documentation/implementation-lifecycle.md`
+- [ ] T011 [US1] Update template documentation to distinguish prompts, agents, skills, and participants in `templates/README.md`
+- [ ] T012 [US1] Ensure new team-member guidance uses `participant` instead of redefining `agent` in `README.md`, `.documentation/implementation-lifecycle.md`, and `templates/README.md`
+
+**Checkpoint**: Core vocabulary is documented and independently reviewable.
+
+---
+
+## Phase 4: User Story 2 - Preserve Existing Customization Layers (Priority: P2)
+
+**Goal**: Participant guidance explicitly preserves current default, team, and
+individual customization behavior.
+
+**Independent Test**: Inspect updated docs and run tests proving the existing
+customization text is still present and participant docs do not introduce a new
+layer model.
+
+### Tests for User Story 2
+
+- [ ] T013 [P] [US2] Add test assertions that `README.md` still documents the existing 3-tier prompt resolution and 2-tier script resolution in `tests/test_participant_metadata_contract.py`
+- [ ] T014 [P] [US2] Add test assertions that participant documentation does not introduce upstream inheritance or a participant override model in `tests/test_participant_metadata_contract.py`
+
+### Implementation for User Story 2
+
+- [ ] T015 [US2] Update `README.md` participant guidance to state that existing customization layers and precedence are unchanged
+- [ ] T016 [US2] Update `.documentation/implementation-lifecycle.md` to state that participant metadata is advisory and does not affect command, prompt, or script resolution
+- [ ] T017 [US2] Update `.documentation/constitution-guide.md` only if needed to clarify that participants do not weaken constitution authority or app-level governance
+
+**Checkpoint**: Participant docs preserve DevSpark's current customization
+process.
+
+---
+
+## Phase 5: User Story 3 - Add Optional Participant Metadata (Priority: P3)
+
+**Goal**: Stock templates show optional `participants` YAML frontmatter examples
+without making metadata mandatory.
+
+**Independent Test**: Inspect generated template examples and run tests that
+verify metadata is optional and artifact-only.
+
+### Tests for User Story 3
+
+- [ ] T018 [P] [US3] Add test assertions that `templates/spec-template.md`, `templates/quick-spec-template.md`, `templates/plan-template.md`, and `templates/tasks-template.md` include optional `participants` YAML frontmatter, and that `templates/plan-template.md` still exposes its `# Implementation Plan` heading after frontmatter is skipped, in `tests/test_participant_metadata_contract.py`
+- [ ] T019 [P] [US3] Add test assertions that `templates/spec-validation-contract.md` documents optional participant metadata as advisory and non-blocking in `tests/test_participant_metadata_contract.py`
+
+### Implementation for User Story 3
+
+- [ ] T020 [US3] Add optional `participants` YAML frontmatter examples to `templates/spec-template.md`
+- [ ] T021 [US3] Add optional `participants` YAML frontmatter examples to `templates/quick-spec-template.md`
+- [ ] T022 [US3] Add optional `participants` YAML frontmatter examples to `templates/plan-template.md` while preserving `# Implementation Plan` as the first body heading
+- [ ] T023 [US3] Add optional `participants` YAML frontmatter examples to `templates/tasks-template.md`
+- [ ] T024 [US3] Update `templates/spec-validation-contract.md` to state that `participants` is optional advisory metadata and absence must not fail validation
+- [ ] T025 [US3] Update `templates/README.md` helper template documentation to mention optional participant metadata in stock lifecycle templates
+
+**Checkpoint**: Stock templates carry optional participant metadata examples and
+existing artifacts without the metadata remain valid.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Validate the full documentation/template change and prepare it for
+review.
+
+- [ ] T026 [P] Run `npx markdownlint-cli2 "README.md" ".documentation/**/*.md" "templates/**/*.md"` and fix markdown issues in changed files
+- [ ] T027 Run `.\.venv\Scripts\python -m pytest -q tests/test_participant_metadata_contract.py` and fix failures
+- [ ] T028 Run `.\.venv\Scripts\python -m pytest -q` and confirm existing test suite passes without participant metadata in fixtures
+- [ ] T029 Run `git diff --check` and fix whitespace or line-ending issues in changed files
+- [ ] T030 Update `.documentation/specs/001-participant-roles/quickstart.md` with final validation notes if commands differ from the planned verification steps
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies.
+- **Foundational (Phase 2)**: Depends on Setup completion and blocks user-story implementation.
+- **User Story 1 (Phase 3)**: Depends on Foundational tests.
+- **User Story 2 (Phase 4)**: Depends on User Story 1 terminology where docs refer to participants.
+- **User Story 3 (Phase 5)**: Depends on Foundational metadata contract tests.
+- **Polish (Phase 6)**: Depends on all desired user stories.
+
+### User Story Dependencies
+
+- **User Story 1 (P1)**: First because all later docs rely on the canonical vocabulary.
+- **User Story 2 (P2)**: Can proceed after US1 wording exists.
+- **User Story 3 (P3)**: Can proceed after metadata tests exist; it can run partly in parallel with US2.
+
+### Parallel Opportunities
+
+- T003 can run in parallel with T001 and T002.
+- T008, T013, T014, T018, and T019 can be split across test file sections after T004.
+- T020 through T023 can be implemented in parallel because they touch separate template files.
+- T026 can run after documentation/template edits; T027 can run after tests are added.
+
+---
+
+## Parallel Example: User Story 3
+
+```text
+Task: "Add optional participants YAML frontmatter examples to templates/spec-template.md"
+Task: "Add optional participants YAML frontmatter examples to templates/quick-spec-template.md"
+Task: "Add optional participants YAML frontmatter examples to templates/plan-template.md"
+Task: "Add optional participants YAML frontmatter examples to templates/tasks-template.md"
+```
+
+---
+
+## Gate Acknowledgements
+
+- `checklist`: No unresolved findings.
+- `analyze`: Findings I1 and I2 resolved in
+  `.documentation/specs/001-participant-roles/gates/analyze.md`.
+- `critic`: Findings `critic-001`, `critic-002`, and `critic-003` resolved by
+  explicit spec metadata and strengthened implementation test tasks.
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1 and Phase 2.
+2. Complete User Story 1 documentation.
+3. Run focused terminology tests and markdownlint on changed docs.
+4. Validate that users can distinguish prompt, agent, skill, participant, and
+   role before extending templates.
+
+### Incremental Delivery
+
+1. Establish tests and vocabulary.
+2. Preserve customization layer guidance.
+3. Add optional metadata examples to stock templates.
+4. Validate markdown and tests.
+
+### Review Strategy
+
+1. Check for accidental redefinition of `agent`.
+2. Check that participant metadata remains optional.
+3. Check that no task adds routing, inheritance, or command-output behavior.
+4. Check that no script parity work is needed because scripts are unchanged.
+
+## Notes
+
+- Participant metadata is artifact-only in this phase.
+- Do not add a participant registry.
+- Do not modify prompt or script resolution precedence.
+- Do not require personal names in examples.

--- a/.documentation/specs/pr-review/pr-47.md
+++ b/.documentation/specs/pr-review/pr-47.md
@@ -14,7 +14,7 @@ summary: "PR satisfies spec lifecycle requirements and scoped tests pass, but ma
 - **Source Branch**: 001-participant-roles
 - **Target Branch**: main
 - **Review Date**: 2026-05-31 16:01:28 UTC
-- **Last Updated**: 2026-05-31 16:01:28 UTC
+- **Last Updated**: 2026-05-31 16:06:42 UTC
 - **Reviewed Commit**: 375e32bdd4bf8ed4d117979afd1d608880a906f2
 - **Reviewer**: devspark.pr-review
 - **Constitution Version**: 1.4.0
@@ -24,6 +24,7 @@ summary: "PR satisfies spec lifecycle requirements and scoped tests pass, but ma
 | Rev | Commit | Date | Critical | High | Medium | Low | CON | Test Command | Result |
 |-----|--------|------|----------|------|--------|-----|-----|--------------|--------|
 | 1 | 375e32b | 2026-05-31 16:01:28 UTC | 0 | 2 | 0 | 0 | 0 | `.\.venv\Scripts\python -m pytest -q tests/test_participant_metadata_contract.py`; `npx markdownlint-cli2 "**/*.md"` | pytest pass; markdownlint fail |
+| 2 | a721a86 | 2026-05-31 16:06:42 UTC | 0 | 0 | 0 | 0 | 0 | `.\.venv\Scripts\python -m pytest -q tests/test_participant_metadata_contract.py`; `npx markdownlint-cli2 "**/*.md"` | pass |
 
 ## PR Summary
 
@@ -32,17 +33,17 @@ summary: "PR satisfies spec lifecycle requirements and scoped tests pass, but ma
 - **Status**: OPEN
 - **Files Changed**: 22
 - **Commits**: 3
-- **Lines**: +1576 -1
+- **Lines**: +1836 -0
 
 ## Stats
 
 | Metric | Value |
 |--------|-------|
 | Files changed | 22 |
-| Lines added | +1576 |
-| Lines removed | -1 |
-| Net lines | +1575 |
-| Commit snapshot | `375e32b` |
+| Lines added | +1836 |
+| Lines removed | -0 |
+| Net lines | +1836 |
+| Commit snapshot | `a721a86` |
 
 Collected via `git diff --numstat origin/main...HEAD`.
 
@@ -65,7 +66,7 @@ Collected via `git diff --numstat origin/main...HEAD`.
 
 ### Immediate Actions (Blocking - must resolve before merge)
 
-- [ ] **H-01** `.github/agents/copilot-instructions.md:5` - Generated participant-role entries removed required blank lines around headings/lists, causing markdownlint MD022 and MD032 failures.
+- [x] **H-01** `.github/agents/copilot-instructions.md:5` - Generated participant-role entries removed required blank lines around headings/lists, causing markdownlint MD022 and MD032 failures. -- *Fixed in a721a86: added required blank lines after the generated section headings.*
   - **Broken code**:
 
     ```markdown
@@ -81,7 +82,7 @@ Collected via `git diff --numstat origin/main...HEAD`.
     - Markdown documentation and YAML frontmatter examples + markdownlint-cli2, pytest (001-participant-roles)
     ```
 
-- [ ] **H-02** `CLAUDE.md:77` - The shared context now introduces a second top-level heading, causing markdownlint MD025.
+- [x] **H-02** `CLAUDE.md:77` - The shared context now introduces a second top-level heading, causing markdownlint MD025. -- *Fixed in a721a86: restored the shared context heading to second-level.*
   - **Broken code**:
 
     ```markdown

--- a/.documentation/specs/pr-review/pr-47.md
+++ b/.documentation/specs/pr-review/pr-47.md
@@ -1,0 +1,259 @@
+# Pull Request Review: Feature Specification: Participant Roles
+
+```yaml
+gate: pr-review
+status: fail
+blocking: true
+severity: error
+summary: "PR satisfies spec lifecycle requirements and scoped tests pass, but markdownlint fails against the constitution-required command."
+```
+
+## Review Metadata
+
+- **PR Number**: #47
+- **Source Branch**: 001-participant-roles
+- **Target Branch**: main
+- **Review Date**: 2026-05-31 16:01:28 UTC
+- **Last Updated**: 2026-05-31 16:01:28 UTC
+- **Reviewed Commit**: 375e32bdd4bf8ed4d117979afd1d608880a906f2
+- **Reviewer**: devspark.pr-review
+- **Constitution Version**: 1.4.0
+
+## Revision Log
+
+| Rev | Commit | Date | Critical | High | Medium | Low | CON | Test Command | Result |
+|-----|--------|------|----------|------|--------|-----|-----|--------------|--------|
+| 1 | 375e32b | 2026-05-31 16:01:28 UTC | 0 | 2 | 0 | 0 | 0 | `.\.venv\Scripts\python -m pytest -q tests/test_participant_metadata_contract.py`; `npx markdownlint-cli2 "**/*.md"` | pytest pass; markdownlint fail |
+
+## PR Summary
+
+- **Author**: @markhazleton
+- **Created**: 2026-05-31T15:53:54Z
+- **Status**: OPEN
+- **Files Changed**: 22
+- **Commits**: 3
+- **Lines**: +1576 -1
+
+## Stats
+
+| Metric | Value |
+|--------|-------|
+| Files changed | 22 |
+| Lines added | +1576 |
+| Lines removed | -1 |
+| Net lines | +1575 |
+| Commit snapshot | `375e32b` |
+
+Collected via `git diff --numstat origin/main...HEAD`.
+
+## Executive Summary
+
+- ✅ **Constitution Compliance**: FAIL (7/8 principles checked; 1 failing)
+- ✅ **Spec Lifecycle**: Complete
+- ✅ **Task Completion**: 30/30 tasks complete
+- ✅ **Security**: 0 issues found
+- ⚠️ **Code Quality**: 2 recommendations
+- ⚠️ **Testing**: pytest PASS; markdownlint FAIL
+- ⚠️ **Documentation**: FAIL
+- ✅ **Constitution Improvements**: 0 CON findings
+
+**Overall Assessment**: The participant terminology and optional metadata work is well-scoped and supported by contract tests. Merge should wait until the generated agent documentation files satisfy the repository-wide markdownlint requirement.
+
+**Approval Recommendation**: ⚠️ REQUEST CHANGES
+
+## Action Items
+
+### Immediate Actions (Blocking - must resolve before merge)
+
+- [ ] **H-01** `.github/agents/copilot-instructions.md:5` - Generated participant-role entries removed required blank lines around headings/lists, causing markdownlint MD022 and MD032 failures.
+  - **Broken code**:
+
+    ```markdown
+    ## Active Technologies
+    - Markdown documentation and YAML frontmatter examples + markdownlint-cli2, pytest (001-participant-roles)
+    ```
+
+  - **Fix**:
+
+    ```markdown
+    ## Active Technologies
+
+    - Markdown documentation and YAML frontmatter examples + markdownlint-cli2, pytest (001-participant-roles)
+    ```
+
+- [ ] **H-02** `CLAUDE.md:77` - The shared context now introduces a second top-level heading, causing markdownlint MD025.
+  - **Broken code**:
+
+    ```markdown
+    <!-- DEVSPARK SHARED CONTEXT:START -->
+    # AGENTS.md
+    ```
+
+  - **Fix**:
+
+    ```markdown
+    <!-- DEVSPARK SHARED CONTEXT:START -->
+    ## AGENTS.md
+    ```
+
+### Recommended Improvements
+
+None found.
+
+### Constitution Improvements (Non-blocking - feed into `/devspark.evolve-constitution`)
+
+None found.
+
+## What's Good
+
+- The spec lifecycle is complete: `spec.md` is `Complete`, and `tasks.md` has 30/30 tasks checked.
+- The PR keeps `agent` reserved for runtime/client integrations and uses `participant` for responsibility-bearing team members.
+- The new contract test file protects optional metadata, advisory behavior, customization-layer preservation, and template frontmatter handling.
+- No scripts were changed, so Platform Parity is not at risk.
+
+## Findings Detail
+
+Stable IDs persist across re-reviews. Status updates instead of deleting.
+
+### Critical Issues (Blocking)
+
+None found.
+
+### High Priority Issues
+
+| ID | Status | Principle | File:Line | Issue | Fix |
+|----|--------|-----------|-----------|-------|-----|
+| H-01 | 🔴 Open | §VIII Markdown Quality | `.github/agents/copilot-instructions.md:5` | Constitution v1.4.0 says every markdown file merged to default branch MUST produce zero markdownlint errors. `npx markdownlint-cli2 "**/*.md"` reports MD022 at line 5 and MD032 at line 6 because the inserted list follows the heading without a blank line. | Add a blank line after `## Active Technologies` and after `## Recent Changes` before the inserted list items. |
+| H-02 | 🔴 Open | §VIII Markdown Quality | `CLAUDE.md:77` | Constitution v1.4.0 says every markdown file merged to default branch MUST produce zero markdownlint errors. `npx markdownlint-cli2 "**/*.md"` reports MD025 because the PR changes `## AGENTS.md` to `# AGENTS.md`, creating a second H1 in the file. | Restore the heading to `## AGENTS.md` or otherwise keep only one top-level heading in `CLAUDE.md`. |
+
+### Medium Priority Suggestions
+
+None found.
+
+### Low Priority Improvements
+
+None found.
+
+### Constitution Improvements
+
+None found.
+
+## Constitution Alignment Details
+
+| Principle | Status | Evidence | Notes |
+|-----------|--------|----------|-------|
+| I. Backward Compatibility | ✅ Pass | `templates/spec-validation-contract.md`, `README.md`, tests | Participant metadata is documented as optional/advisory and existing artifacts without `participants` remain valid. |
+| II. Explicit Over Implied | ✅ Pass | PR body, spec frontmatter, participant metadata contract | Scope is repo-level documentation/template work; metadata is explicit when present and not inferred into behavior. |
+| III. Ownership Boundary | ✅ Pass | Changed files under repo-owned docs/templates/tests | No install/upgrade flow changes write to `.documentation/`; repository-owned spec artifacts are valid work product. |
+| IV. Governance Authority | ✅ Pass | `.documentation/constitution-guide.md` | Participant guidance does not weaken constitution authority or app-level governance. |
+| V. Simplicity | ✅ Pass | `templates/spec-validation-contract.md` | The PR avoids participant routing, registries, inheritance, and command-output behavior. |
+| VI. Platform Parity | ✅ Pass | No script changes | No Bash/PowerShell parity surface changed. |
+| VII. PR Review Artifact Commit Discipline | ✅ Pass | No prior review artifact in branch | Review artifact is generated in this working tree and should be committed separately from code fixes. |
+| VIII. Markdown Quality | ❌ Fail | `npx markdownlint-cli2 "**/*.md"` | 5 markdownlint errors remain in changed files. |
+
+## Security Checklist
+
+- [x] No hardcoded secrets or credentials
+- [x] Input validation present where needed
+- [x] Authentication/authorization checks appropriate
+- [x] No SQL injection vulnerabilities
+- [x] No XSS vulnerabilities
+- [x] Dependencies reviewed for vulnerabilities
+
+Notes: This PR changes documentation, templates, spec artifacts, and one test file. No runtime auth, database, browser rendering, or dependency surface changed. Keyword scan results were documentation references, placeholders, tests, or existing workflow examples, not newly introduced credentials.
+
+## Testing Coverage
+
+**Status**: ADEQUATE, pending markdownlint fix
+
+- Scoped changed-test run: `.\.venv\Scripts\python -m pytest -q tests/test_participant_metadata_contract.py` -> 9 passed.
+- Constitution markdown check: `npx markdownlint-cli2 "**/*.md"` -> 5 errors.
+- `git diff --check origin/main...HEAD` -> pass.
+
+## Test Inventory
+
+Count of test functions per changed test file. Unjustified removals are MEDIUM findings.
+
+| File | Main | Branch | Delta | Justification |
+|------|------|--------|-------|---------------|
+| `tests/test_participant_metadata_contract.py` | 0 | 9 | +9 | New contract coverage for participant terminology and optional metadata. |
+| **Total** | 0 | 9 | +9 | |
+
+Removed tests: none.
+
+## Documentation Status
+
+**Status**: INADEQUATE until lint errors are fixed
+
+The documentation changes are directionally correct and aligned with the feature spec, but two changed markdown files currently fail the constitution-required markdownlint command.
+
+## Changed Files Summary
+
+| File | Tier | Changes | Type | Findings |
+|------|------|---------|------|----------|
+| `.documentation/constitution-guide.md` | P3 | +4 -0 | Modified | None |
+| `.documentation/implementation-lifecycle.md` | P3 | +17 -0 | Modified | None |
+| `.documentation/specs/001-participant-roles/checklists/requirements.md` | P3 | +42 -0 | Added | None |
+| `.documentation/specs/001-participant-roles/contracts/participant-metadata.md` | P3 | +92 -0 | Added | None |
+| `.documentation/specs/001-participant-roles/data-model.md` | P3 | +117 -0 | Added | None |
+| `.documentation/specs/001-participant-roles/gates/analyze.md` | P3 | +77 -0 | Added | None |
+| `.documentation/specs/001-participant-roles/gates/critic.md` | P3 | +131 -0 | Added | None |
+| `.documentation/specs/001-participant-roles/plan.md` | P3 | +174 -0 | Added | None |
+| `.documentation/specs/001-participant-roles/quickstart.md` | P3 | +57 -0 | Added | None |
+| `.documentation/specs/001-participant-roles/research.md` | P3 | +83 -0 | Added | None |
+| `.documentation/specs/001-participant-roles/spec.md` | P3 | +262 -0 | Added | None |
+| `.documentation/specs/001-participant-roles/tasks.md` | P3 | +262 -0 | Added | None |
+| `.github/agents/copilot-instructions.md` | P3 | +2 -0 | Modified | H-01 |
+| `CLAUDE.md` | P3 | +1 -1 | Modified | H-02 |
+| `README.md` | P3 | +23 -0 | Modified | None |
+| `templates/README.md` | P3 | +16 -0 | Modified | None |
+| `templates/plan-template.md` | P3 | +10 -0 | Modified | None |
+| `templates/quick-spec-template.md` | P3 | +7 -0 | Modified | None |
+| `templates/spec-template.md` | P3 | +7 -0 | Modified | None |
+| `templates/spec-validation-contract.md` | P3 | +21 -0 | Modified | None |
+| `templates/tasks-template.md` | P3 | +7 -0 | Modified | None |
+| `tests/test_participant_metadata_contract.py` | P2 | +164 -0 | Added | None |
+
+## Behavioral Changes
+
+None detected. The PR documents optional metadata and adds template examples without changing command execution, prompt resolution, script resolution, validation enforcement, or runtime behavior.
+
+## Approval Decision
+
+**Recommendation**: ⚠️ REQUEST CHANGES
+
+**Reasoning**:
+The feature spec is complete, tasks are complete, and scoped tests pass. However, Constitution §VIII requires every markdown file merged to default branch to pass `npx markdownlint-cli2 "**/*.md"` with zero errors, and the PR currently introduces five markdownlint errors in changed files.
+
+**Estimated Rework Time**: 15 minutes
+
+---
+
+*Review generated by devspark.pr-review v1.2*
+*Constitution-driven code review for DevSpark*
+*To re-review after fixes: `/devspark.pr-review #47 re-review`*
+*When addressing these findings, run `/devspark.address-pr-review 47`. The review file must be committed on its own -- this rule is enforced by the prompt and can also be enforced by the optional pre-commit hook.*
+
+## Previous Review History
+
+None.
+
+## Shared Review Resolution Contract Output
+
+```yaml
+findings:
+  - finding_id: H-01
+    severity: high
+    description: ".github/agents/copilot-instructions.md fails markdownlint MD022/MD032 because inserted participant-role list items are not separated from headings by required blank lines."
+    recommended_action: "Add blank lines after the Active Technologies and Recent Changes headings before the inserted list items, then rerun npx markdownlint-cli2 \"**/*.md\"."
+    execution_mode: auto
+    status: open
+    outcome: ""
+  - finding_id: H-02
+    severity: high
+    description: "CLAUDE.md fails markdownlint MD025 because the PR changes the shared context heading to a second H1."
+    recommended_action: "Restore the shared context heading to ## AGENTS.md or otherwise keep a single top-level heading, then rerun npx markdownlint-cli2 \"**/*.md\"."
+    execution_mode: auto
+    status: open
+    outcome: ""
+```

--- a/.github/agents/copilot-instructions.md
+++ b/.github/agents/copilot-instructions.md
@@ -3,6 +3,7 @@
 Auto-generated from all feature plans. Last updated: 2026-04-18
 
 ## Active Technologies
+
 - Markdown documentation and YAML frontmatter examples + markdownlint-cli2, pytest (001-participant-roles)
 
 - Python 3.11+ + typer, click, rich, pydantic, jsonschema, PyYAML (001-harness-delivery-integrity)
@@ -26,6 +27,7 @@ cd src; pytest; ruff check .
 Python 3.11+: Follow standard conventions
 
 ## Recent Changes
+
 - 001-participant-roles: Added Markdown documentation and YAML frontmatter examples + markdownlint-cli2, pytest
 
 - 001-harness-delivery-integrity: Added Python 3.11+ + typer, click, rich, pydantic, jsonschema, PyYAML

--- a/.github/agents/copilot-instructions.md
+++ b/.github/agents/copilot-instructions.md
@@ -3,6 +3,7 @@
 Auto-generated from all feature plans. Last updated: 2026-04-18
 
 ## Active Technologies
+- Markdown documentation and YAML frontmatter examples + markdownlint-cli2, pytest (001-participant-roles)
 
 - Python 3.11+ + typer, click, rich, pydantic, jsonschema, PyYAML (001-harness-delivery-integrity)
 - File-based artifacts under `.documentation/specs/*` and `.documentation/devspark/runs/*` (001-harness-delivery-integrity)
@@ -25,6 +26,7 @@ cd src; pytest; ruff check .
 Python 3.11+: Follow standard conventions
 
 ## Recent Changes
+- 001-participant-roles: Added Markdown documentation and YAML frontmatter examples + markdownlint-cli2, pytest
 
 - 001-harness-delivery-integrity: Added Python 3.11+ + typer, click, rich, pydantic, jsonschema, PyYAML
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,7 +74,7 @@ Full list in `templates/commands/`.
 - Never overwrite `.documentation/` user artifacts during CLI operations
 
 <!-- DEVSPARK SHARED CONTEXT:START -->
-## AGENTS.md
+# AGENTS.md
 
 ## About DevSpark
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,7 +74,7 @@ Full list in `templates/commands/`.
 - Never overwrite `.documentation/` user artifacts during CLI operations
 
 <!-- DEVSPARK SHARED CONTEXT:START -->
-# AGENTS.md
+## AGENTS.md
 
 ## About DevSpark
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,25 @@ devspark/
 └── .documentation/       ← Guides, media, and GitHub Pages site
 ```
 
+## DevSpark Vocabulary
+
+- **Prompt**: A workflow command surface, usually a slash-command file, that
+  orchestrates DevSpark lifecycle behavior such as specification, planning,
+  implementation, review, or release.
+- **Agent**: An AI runtime or client integration such as Codex, Claude,
+  Copilot, Cursor, or Gemini. Agent metadata lives in `agents-registry.json`
+  and describes supported integrations, not team responsibilities.
+- **Skill**: A reusable portable capability package that a prompt can delegate
+  to when specialized task knowledge is useful.
+- **Participant**: A human or AI-filled team member carrying responsibility for
+  work, review, approval, critique, or decision capture in a workflow.
+- **Role**: A responsibility label assigned to a participant, such as owner,
+  planner, implementer, reviewer, critic, or scribe.
+
+Participant metadata is optional advisory context in artifacts. It does not
+change prompt resolution, script resolution, command behavior, or the existing
+customization process.
+
 ## Agent Skills
 
 DevSpark treats skills as portable capability packages within a governed lifecycle
@@ -254,6 +273,10 @@ DevSpark cleanly separates **your work** from **its installation**:
 2. `.devspark/scripts/` — Stock scripts
 
 There is no third ownership tier. If an organization wants a shared baseline in `.documentation/`, it manages that through its own repo practices; DevSpark still only writes to `.devspark/`.
+
+Participant metadata uses these existing repository-owned artifacts when present.
+It does not change how prompts or scripts are found; customization layers and
+precedence are unchanged.
 
 **Clean removal**: `devspark uninstall` removes `.devspark/` and agent shims, leaves `.documentation/` untouched.
 

--- a/templates/README.md
+++ b/templates/README.md
@@ -6,6 +6,16 @@ This directory contains the **core deliverable** of DevSpark — prompt template
 
 Each file in `commands/` is a slash-command prompt (e.g., `/devspark.specify`, `/devspark.plan`). When you run `devspark init`, stock prompts are deployed to `.devspark/defaults/commands/`. AI shims then resolve prompts via the 3-tier order: personal override, team override, then stock default.
 
+Terminology used by these templates:
+
+- **Prompt** files are DevSpark workflow command surfaces.
+- **Agents** are AI runtime or client integrations that execute prompts.
+- **Skills** are portable capability packages prompts may delegate to.
+- **Participants** are human or AI-filled team members responsible for work,
+  review, critique, approval, or decision capture.
+- **Roles** are responsibility labels for participants, such as owner, planner,
+  implementer, reviewer, critic, or scribe.
+
 DevSpark ownership is strictly two-tier:
 
 - `.devspark/` is framework-managed stock content
@@ -58,3 +68,9 @@ The collection includes 27 active commands plus 1 deprecated compatibility alias
 | `spec-validation-contract.md` | Shared validation contract for spec structure and required content |
 | `agent-file-template.md` | Template for agent configuration files |
 | `vscode-settings.json` | Recommended VS Code settings |
+
+The stock spec, quick-spec, plan, and tasks templates include optional
+`participants` YAML frontmatter examples. This metadata is advisory
+responsibility context only. It is not required for existing artifacts, does
+not affect prompt or script resolution, and does not change command output.
+Customization layers and precedence are unchanged.

--- a/templates/plan-template.md
+++ b/templates/plan-template.md
@@ -1,3 +1,13 @@
+---
+participants:
+  owner: human
+  planner: ai
+  implementer: ai
+  reviewer: human
+  critic: ai
+  scribe: ai
+---
+
 # Implementation Plan: [FEATURE]
 
 **Branch**: `[###-feature-name]` | **Date**: [DATE] | **Spec**: [link]

--- a/templates/quick-spec-template.md
+++ b/templates/quick-spec-template.md
@@ -5,6 +5,13 @@ target_workflow: specify-light
 required_artifacts: intent, action-plan
 recommended_next_step: plan
 required_gates: checklist
+participants:
+  owner: human
+  planner: ai
+  implementer: ai
+  reviewer: human
+  critic: ai
+  scribe: ai
 ---
 
 # Quick Specification: [FEATURE NAME]

--- a/templates/spec-template.md
+++ b/templates/spec-template.md
@@ -5,6 +5,13 @@ target_workflow: specify-full
 required_artifacts: spec, plan, tasks
 recommended_next_step: plan
 required_gates: checklist, analyze, critic
+participants:
+  owner: human
+  planner: ai
+  implementer: ai
+  reviewer: human
+  critic: ai
+  scribe: ai
 ---
 
 # Feature Specification: [FEATURE NAME]

--- a/templates/spec-validation-contract.md
+++ b/templates/spec-validation-contract.md
@@ -16,6 +16,13 @@ target_workflow: specify-light | specify-full
 required_artifacts: intent, action-plan | spec, plan, tasks
 recommended_next_step: plan | clarify | implement
 required_gates: checklist | checklist, analyze, critic
+participants:
+  owner: human
+  planner: ai
+  implementer: ai
+  reviewer: human
+  critic: ai
+  scribe: ai
 ```
 
 Validation rules:
@@ -24,7 +31,14 @@ Validation rules:
 - `quick-spec` maps to `specify-light` and `intent, action-plan`.
 - `full-spec` maps to `specify-full` and `spec, plan, tasks`.
 - `required_gates` MUST match the chosen route unless the spec explicitly documents why additional gates were added.
+- `participants` is optional advisory metadata. Its absence must not fail
+  validation, block a workflow, alter prompt resolution, alter script
+  resolution, or change command output.
 - If frontmatter conflicts with body prose, treat frontmatter as authoritative and either repair the prose or flag the inconsistency.
+
+Participant examples should use role-to-kind values such as `owner: human` or
+`implementer: ai`. Stock examples must avoid personally identifying information.
+Teams that add display labels own their own privacy handling.
 
 ## 2. Lifecycle State Contract
 
@@ -130,3 +144,10 @@ When validation fails:
 - If a missing or malformed item can be repaired directly from route metadata or obvious existing content, repair it.
 - If classification or required section intent cannot be inferred safely, stop and ask the user to rerun `/devspark.specify` or repair the spec manually.
 - Never silently drop user-authored requirements to make the document fit the contract.
+
+## 7. Participant Metadata Non-Goals
+
+Participant metadata is silent artifact-only context in this phase. It must not
+create workflow dispatch behavior, a participant registry, reviewer lockout,
+metadata-based inheritance, metadata-based customization precedence, or a
+dedicated command-output summary.

--- a/templates/tasks-template.md
+++ b/templates/tasks-template.md
@@ -1,5 +1,12 @@
 ---
 description: "Task list template for feature implementation"
+participants:
+  owner: human
+  planner: ai
+  implementer: ai
+  reviewer: human
+  critic: ai
+  scribe: ai
 ---
 
 # Tasks: [FEATURE NAME]

--- a/tests/test_participant_metadata_contract.py
+++ b/tests/test_participant_metadata_contract.py
@@ -1,0 +1,164 @@
+"""Contract tests for optional participant metadata and terminology.
+
+These tests protect the phase-one participant vocabulary decision:
+``agent`` remains an AI runtime/client integration, while ``participant`` is
+the advisory team-member concept carried only in documentation artifacts.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parent.parent
+
+DOC_PATHS = [
+    ROOT / "README.md",
+    ROOT / ".documentation" / "implementation-lifecycle.md",
+    ROOT / ".documentation" / "constitution-guide.md",
+    ROOT / "templates" / "README.md",
+]
+
+LIFECYCLE_TEMPLATE_PATHS = [
+    ROOT / "templates" / "spec-template.md",
+    ROOT / "templates" / "quick-spec-template.md",
+    ROOT / "templates" / "plan-template.md",
+    ROOT / "templates" / "tasks-template.md",
+]
+
+ROLE_NAMES = {"owner", "planner", "implementer", "reviewer", "critic", "scribe"}
+KINDS = {"human", "ai"}
+
+
+def read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def frontmatter_and_body(path: Path) -> tuple[dict, str]:
+    text = read(path)
+    if not text.startswith("---\n"):
+        return {}, text
+    parts = text.split("---", 2)
+    assert len(parts) == 3, f"{path} has malformed frontmatter"
+    return yaml.safe_load(parts[1]) or {}, parts[2].lstrip()
+
+
+def participants_from(path: Path) -> dict:
+    frontmatter, _ = frontmatter_and_body(path)
+    participants = frontmatter.get("participants")
+    assert isinstance(participants, dict), f"{path} must include participants metadata"
+    return participants
+
+
+def test_existing_artifacts_without_participants_metadata_remain_valid() -> None:
+    sample_without_participants = """---
+classification: full-spec
+risk_level: medium
+target_workflow: specify-full
+required_artifacts: spec, plan, tasks
+recommended_next_step: plan
+required_gates: checklist, analyze, critic
+---
+
+# Feature Specification: Existing Artifact
+"""
+    frontmatter = yaml.safe_load(sample_without_participants.split("---", 2)[1])
+    assert "participants" not in frontmatter
+
+    contract = read(ROOT / "templates" / "spec-validation-contract.md").lower()
+    assert "participants" in contract
+    assert "optional" in contract
+    assert "must not fail" in contract or "not fail" in contract
+
+
+def test_stock_docs_reserve_agent_for_runtime_integrations() -> None:
+    combined = "\n".join(read(path) for path in DOC_PATHS).lower()
+    assert "agent" in combined
+    assert "ai runtime" in combined or "runtime/client integration" in combined
+    assert "agents-registry.json" in combined
+    assert "participant" in combined
+    assert "team member" in combined or "team-member" in combined
+    assert "agent as a team member" not in combined
+    assert "agents are participants" not in combined
+
+
+def test_participant_metadata_examples_avoid_pii_and_runtime_behavior() -> None:
+    combined = "\n".join(read(path) for path in [*LIFECYCLE_TEMPLATE_PATHS, ROOT / "templates" / "spec-validation-contract.md"]).lower()
+
+    assert "personally identifying information" in combined
+    assert "artifact-only" in combined or "advisory" in combined
+    assert "silent" in combined or "command output" in combined
+
+    forbidden_recommendations = [
+        "recommended to store personal",
+        "recommend storing personal",
+        "required name",
+        "participant routing",
+        "participant inheritance",
+        "participant override",
+        "print participant",
+    ]
+    assert not [phrase for phrase in forbidden_recommendations if phrase in combined]
+
+
+def test_readme_defines_required_glossary_terms() -> None:
+    readme = read(ROOT / "README.md").lower()
+    for term in ["prompt", "agent", "skill", "participant", "role"]:
+        pattern = rf"\*\*{re.escape(term)}\*\*"
+        assert re.search(pattern, readme), f"README glossary must define {term}"
+
+    assert "workflow command surface" in readme
+    assert "ai runtime or client integration" in readme
+    assert "portable capability package" in readme
+    assert "human or ai-filled team member" in readme
+    assert "responsibility label" in readme
+
+
+def test_customization_resolution_layers_remain_documented() -> None:
+    readme = read(ROOT / "README.md")
+    assert "**3-tier prompt resolution**" in readme
+    assert ".documentation/{git-user}/commands/" in readme
+    assert ".documentation/commands/" in readme
+    assert ".devspark/defaults/commands/" in readme
+    assert "**2-tier script resolution**" in readme
+    assert ".documentation/scripts/" in readme
+    assert ".devspark/scripts/" in readme
+
+
+def test_participant_guidance_does_not_add_override_or_inheritance_model() -> None:
+    combined = "\n".join(read(path) for path in DOC_PATHS).lower()
+    assert "participant override" not in combined
+    assert "participant inheritance" not in combined
+    assert "upstream participant" not in combined
+    assert "new customization layer" not in combined
+    assert "customization layers and precedence are unchanged" in combined
+
+
+def test_lifecycle_templates_include_optional_participants_metadata() -> None:
+    for path in LIFECYCLE_TEMPLATE_PATHS:
+        participants = participants_from(path)
+        assert ROLE_NAMES <= set(participants)
+        for role, value in participants.items():
+            if isinstance(value, str):
+                assert value in KINDS, f"{path} participant {role} has invalid kind"
+                continue
+            assert isinstance(value, dict), f"{path} participant {role} must be string or map"
+            assert value.get("kind") in KINDS
+            assert "name" not in value, f"{path} stock examples must avoid personal names"
+
+
+def test_plan_template_body_heading_survives_frontmatter() -> None:
+    _, body = frontmatter_and_body(ROOT / "templates" / "plan-template.md")
+    first_heading = next(line for line in body.splitlines() if line.startswith("#"))
+    assert first_heading == "# Implementation Plan: [FEATURE]"
+
+
+def test_spec_validation_contract_documents_nonblocking_participants() -> None:
+    contract = read(ROOT / "templates" / "spec-validation-contract.md").lower()
+    assert "participants" in contract
+    assert "optional advisory metadata" in contract
+    assert "absence" in contract
+    assert "must not fail" in contract or "must not block" in contract


### PR DESCRIPTION
## Summary
- Document the participant roles feature and complete the lifecycle spec status.
- Define prompt, agent, skill, participant, and role vocabulary while keeping `agent` reserved for AI runtime/client integrations.
- Add optional advisory `participants` metadata examples to stock lifecycle templates without changing command, prompt, script, or customization precedence.
- Add contract tests for participant vocabulary, optional metadata behavior, and template/frontmatter preservation.

## Changes
- Branch diff: 22 files changed, 1576 insertions(+), 1 deletion(-).
- Includes participant-role spec artifacts, lifecycle/constitution/README documentation updates, template metadata examples, and `tests/test_participant_metadata_contract.py`.

## Task Completion
- 30/30 tasks complete.
- Checklist `requirements.md`: 20/20 complete, status pass.

## Quality Gates
- `analyze`: pass - prior wording inconsistencies were repaired; artifacts are aligned for implementation.
- `critic`: pass - critic findings were resolved with explicit metadata and strengthened implementation test tasks.
- `checklist`: pass - no unresolved findings.

## Gate Acknowledgements
- `checklist`: No unresolved findings.
- `analyze`: Findings I1 and I2 resolved in `.documentation/specs/001-participant-roles/gates/analyze.md`.
- `critic`: Findings `critic-001`, `critic-002`, and `critic-003` resolved by explicit spec metadata and strengthened implementation test tasks.

## Validation
- `npx markdownlint-cli2 "README.md" ".documentation/**/*.md" "templates/**/*.md"`
- `.\.venv\Scripts\python -m pytest -q tests/test_participant_metadata_contract.py`
- `.\.venv\Scripts\python -m pytest -q`
- `git diff --check`

## Spec Reference
- `.documentation/specs/001-participant-roles/spec.md`